### PR TITLE
fix(tests): repair test_repo_uv_lock_files_use_only_default_pypi_sources

### DIFF
--- a/scripts/check_uv_lock_sources.py
+++ b/scripts/check_uv_lock_sources.py
@@ -43,9 +43,7 @@ _ALLOWED = re.compile(
 
 
 def _is_excluded_dir(name: str) -> bool:
-    if name in _EXCLUDED_DIR_NAMES:
-        return True
-    return name.startswith(".") and name not in {".", ".."}
+    return name in _EXCLUDED_DIR_NAMES or name.startswith(".")
 
 
 def find_uv_lock_files(root: Path) -> list[Path]:

--- a/scripts/check_uv_lock_sources.py
+++ b/scripts/check_uv_lock_sources.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import sys
 from pathlib import Path
@@ -57,21 +58,10 @@ def find_uv_lock_files(root: Path) -> list[Path]:
 
     root = root.resolve()
     matches: list[Path] = []
-
-    def walk(directory: Path) -> None:
-        try:
-            entries = list(directory.iterdir())
-        except (PermissionError, FileNotFoundError):
-            return
-        for entry in entries:
-            if entry.is_dir():
-                if _is_excluded_dir(entry.name):
-                    continue
-                walk(entry)
-            elif entry.is_file() and entry.name == "uv.lock":
-                matches.append(entry)
-
-    walk(root)
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if not _is_excluded_dir(d)]
+        if "uv.lock" in filenames:
+            matches.append(Path(dirpath) / "uv.lock")
     return sorted(matches)
 
 

--- a/scripts/check_uv_lock_sources.py
+++ b/scripts/check_uv_lock_sources.py
@@ -10,6 +10,18 @@ from pathlib import Path
 
 PYPI = "https://pypi.org/simple"
 
+_EXCLUDED_DIR_NAMES = frozenset(
+    {
+        ".git",
+        ".tox",
+        "__pycache__",
+        "build",
+        "dist",
+        "node_modules",
+        "venv",
+    }
+)
+
 _SOURCE = re.compile(
     r"""
     ^\s*
@@ -29,6 +41,40 @@ _ALLOWED = re.compile(
 )
 
 
+def _is_excluded_dir(name: str) -> bool:
+    if name in _EXCLUDED_DIR_NAMES:
+        return True
+    return name.startswith(".") and name not in {".", ".."}
+
+
+def find_uv_lock_files(root: Path) -> list[Path]:
+    """Return all ``uv.lock`` files under ``root``, excluding noise directories.
+
+    Excluded directory names: anything in ``_EXCLUDED_DIR_NAMES`` plus any
+    directory whose name starts with ``.`` (e.g. ``.venv``, ``.git``, ``.tox``).
+    Results are sorted for deterministic ordering.
+    """
+
+    root = root.resolve()
+    matches: list[Path] = []
+
+    def walk(directory: Path) -> None:
+        try:
+            entries = list(directory.iterdir())
+        except (PermissionError, FileNotFoundError):
+            return
+        for entry in entries:
+            if entry.is_dir():
+                if _is_excluded_dir(entry.name):
+                    continue
+                walk(entry)
+            elif entry.is_file() and entry.name == "uv.lock":
+                matches.append(entry)
+
+    walk(root)
+    return sorted(matches)
+
+
 def validate_lock_file(lockfile: Path) -> bool:
     for line in lockfile.read_text(encoding="utf-8").splitlines():
         match = _SOURCE.match(line)
@@ -43,7 +89,7 @@ def validate_lock_file(lockfile: Path) -> bool:
 
 
 def main() -> int:
-    lockfiles = sorted(Path.cwd().rglob("uv.lock"))
+    lockfiles = find_uv_lock_files(Path.cwd())
     bad_files = [f for f in lockfiles if not validate_lock_file(f)]
     if bad_files:
         print("uv.lock validation failed:", file=sys.stderr)

--- a/tests/test_uv_lock_sources.py
+++ b/tests/test_uv_lock_sources.py
@@ -23,10 +23,32 @@ spec.loader.exec_module(validator)
 def test_repo_uv_lock_files_use_only_default_pypi_sources() -> None:
     lockfiles = validator.find_uv_lock_files(REPO_ROOT)
 
-    assert lockfiles == [REPO_ROOT / "code-samples" / "uv.lock", REPO_ROOT / "uv.lock"]
+    assert lockfiles, "expected at least one uv.lock file in the repository"
+    assert (REPO_ROOT / "uv.lock").resolve() in lockfiles
 
     for lockfile in lockfiles:
         assert validator.validate_lock_file(lockfile) is True
+
+
+def test_find_uv_lock_files_skips_noise_directories(tmp_path: Path) -> None:
+    (tmp_path / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+
+    nested = tmp_path / "packages" / "member"
+    nested.mkdir(parents=True)
+    (nested / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+
+    for excluded in (".venv", ".git", "node_modules", "__pycache__", ".tox", "dist", "build", "venv"):
+        excluded_dir = tmp_path / excluded
+        excluded_dir.mkdir()
+        (excluded_dir / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+
+    hidden = tmp_path / ".hidden"
+    hidden.mkdir()
+    (hidden / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+
+    found = validator.find_uv_lock_files(tmp_path)
+
+    assert found == sorted([(tmp_path / "uv.lock").resolve(), (nested / "uv.lock").resolve()])
 
 
 def test_custom_registry_source_is_rejected(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

`tests/test_uv_lock_sources.py::test_repo_uv_lock_files_use_only_default_pypi_sources` was failing with:

```
AttributeError: module 'check_uv_lock_sources' has no attribute 'find_uv_lock_files'
```

Two root causes (from #48):

1. The test calls `validator.find_uv_lock_files(REPO_ROOT)`, but the function was never added to `scripts/check_uv_lock_sources.py` — the script only does inline `Path.cwd().rglob("uv.lock")` inside `main()`.
2. The test asserted the result equals `[REPO_ROOT/"code-samples"/"uv.lock", REPO_ROOT/"uv.lock"]`, but `code-samples/` doesn't exist in the repo.

## Changes

- **`scripts/check_uv_lock_sources.py`**: add `find_uv_lock_files(root)` helper. Walks recursively, returns sorted absolute paths, and skips noise directories (`.venv`, `.git`, `node_modules`, `__pycache__`, `.tox`, `dist`, `build`, `venv`, and any dotted directory). Refactor `main()` to use it so script and test share discovery semantics.
- **`tests/test_uv_lock_sources.py`**: replace the brittle exact-equality assertion with "non-empty AND root `uv.lock` present"; keep the per-file validation loop. Add a `tmp_path` unit test pinning the exclusion rules.

## Verification

```
$ uv run pytest tests/test_uv_lock_sources.py -v
============================== 5 passed in 0.03s ===============================

$ uv run python scripts/check_uv_lock_sources.py
Validated 1 uv.lock file(s).

$ uv run ruff check scripts/check_uv_lock_sources.py tests/test_uv_lock_sources.py
All checks passed!
```

## Checklist

- [x] I have read the contributing guide and the code of conduct