### PR TITLE
Fix kriging tools for evo-compute SDK update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "fastmcp>=3.2.4",
     "google-adk==1.28.1",
     "evo-files>=0.2.4",
-    "evo-compute>=0.0.2",
+    "evo-compute>=0.0.4",
     "evo-objects>=0.4.0",
     "evo-sdk-common>=0.5.21",
     "evo-schemas>=2025.9.2",

--- a/src/evo_mcp/tools/compute_tools.py
+++ b/src/evo_mcp/tools/compute_tools.py
@@ -11,15 +11,14 @@ from typing import Any
 from evo.common import StaticContext
 from evo.compute.tasks import run as run_compute
 from evo.compute.tasks.common import (
+    Filter,
     SearchNeighborhood,
     Source,
-    Target,
 )
-from evo.compute.tasks.kriging import (
+from evo.compute.tasks.geostatistics.kriging import (
     BlockDiscretisation,
     KrigingParameters,
     OrdinaryKriging,
-    RegionFilter,
     SimpleKriging,
 )
 from evo.objects.typed import object_from_uuid
@@ -64,9 +63,21 @@ class KrigingBuildParams(BaseModel):
         default_factory=OrdinaryKriging,
         description="Kriging method object. Defaults to ordinary kriging.",
     )
-    target_region_filter: RegionFilter | None = Field(
+    source_filter: Filter | None = Field(
         default=None,
-        description="Optional region filter for the target object.",
+        description=(
+            "Optional filter restricting kriging to a subset of the source samples. "
+            "Provide a Filter with a 'where' condition, e.g. "
+            "{'where': {'attribute': 'grade', 'operator': 'greater_than', 'threshold': 0.0}}."
+        ),
+    )
+    target_filter: Filter | None = Field(
+        default=None,
+        description=(
+            "Optional filter restricting kriging to a subset of the target object. "
+            "Provide a Filter with a 'where' condition, e.g. "
+            "{'where': {'attribute': 'domain', 'operator': 'in', 'values': ['LMS1', 'LMS2']}}."
+        ),
     )
     block_discretisation: BlockDiscretisation | None = Field(
         default=None,
@@ -85,12 +96,22 @@ def _normalize_kriging_payload(payload: dict[str, Any]) -> dict[str, Any]:
     - `search` -> `neighborhood`, `method` -> `kriging_method`.
     - SearchNeighborhood serialization emits `ellipsoid_ranges`, while
       Ellipsoid construction expects `ranges`.
+    - KrigingParameters serializes `source_filter`/`target_filter` into the
+      backend-shaped `source.filter`/`target.filter` (the fields are excluded
+      from the model dump). Relocate them back to the top-level input fields so
+      the filters survive the `kriging_build_parameters` -> `kriging_run`
+      round-trip instead of being silently dropped on re-parse.
     """
     if "search" in payload and "neighborhood" not in payload:
         payload["neighborhood"] = payload.pop("search")
 
     if "method" in payload and "kriging_method" not in payload:
         payload["kriging_method"] = payload.pop("method")
+
+    for side, field in (("source", "source_filter"), ("target", "target_filter")):
+        container = payload.get(side)
+        if isinstance(container, dict) and "filter" in container:
+            payload[field] = container.pop("filter")
 
     neighborhood = payload.get("neighborhood")
     if not isinstance(neighborhood, dict):
@@ -131,7 +152,7 @@ def register_compute_tools(mcp) -> None:
         if not params.target_attribute or not params.target_attribute.strip():
             raise ValueError(
                 "target_attribute must be a non-empty string. "
-                "Specify the name of the attribute to create on the target block model (e.g. 'OK_estimate')."
+                "Specify the name of the attribute to create or update on the target block model (e.g. 'OK_estimate')."
             )
         environment = await get_workspace_environment(workspace_id)
         evo_context = await get_evo_context()
@@ -142,13 +163,21 @@ def register_compute_tools(mcp) -> None:
             object_from_uuid(context, params.variogram_object_id),
         )
         source_attribute = source_object.attributes[params.point_set_attribute]
+        if not getattr(source_attribute, "exists", True):
+            available = [name for a in source_object.attributes if isinstance(name := getattr(a, "name", None), str)]
+            raise ValueError(
+                f"point_set_attribute '{params.point_set_attribute}' does not exist on the source point set. "
+                f"A kriging source must reference an existing attribute containing the sample values. "
+                f"Available attributes: {available}."
+            )
         payload = KrigingParameters(
             source=Source(object=source_object, attribute=source_attribute),
-            target=Target.new_attribute(target_object, params.target_attribute),
+            target=target_object.attributes[params.target_attribute],
             variogram=variogram_object,
             search=params.search,
             method=params.method,
-            target_region_filter=params.target_region_filter,
+            source_filter=params.source_filter,
+            target_filter=params.target_filter,
             block_discretisation=params.block_discretisation,
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -782,7 +782,7 @@ utils = [
 
 [[package]]
 name = "evo-compute"
-version = "0.0.2"
+version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "evo-blockmodels", extra = ["utils"] },
@@ -791,9 +791,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/db/74af15545151b23e4ab133dd4a05bca1a7dc2e052d654f3791590b7fbf79/evo_compute-0.0.2.tar.gz", hash = "sha256:2c445333f4becb0c69253e2423f825ef14ab3e3f366a2a483d9c223c245f306a", size = 24270, upload-time = "2026-03-08T21:49:44.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/d9/1e59b6e8ce7f8a9d726d330951eef61bb8284efb2431ae5d0d063be5e436/evo_compute-0.0.4.tar.gz", hash = "sha256:a1e58ed239e7130ba12705e5801cec384ea6bea5a81324fdf5576e5be1c82832", size = 39496, upload-time = "2026-07-01T21:44:30.349Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/93/2ba09e0d2d94ec2f38f0f7480242e66dbf7e9f9e8002bc9e9c75813b3583/evo_compute-0.0.2-py3-none-any.whl", hash = "sha256:021250b8195d4d285b716568c3f85d32331eb12e4c499bd1ba0093ed0f2ff22e", size = 38015, upload-time = "2026-03-08T21:49:43.171Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/6fe6a782db10d9ef47d72d74d1f0e9945daab046dbb2ca816a7db1add8cc/evo_compute-0.0.4-py3-none-any.whl", hash = "sha256:21c64ede91d278a41408c204efe75eaa4d86c753c0afe2634a99a5c1070e8a99", size = 76169, upload-time = "2026-07-01T21:44:28.971Z" },
 ]
 
 [[package]]
@@ -844,7 +844,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.0" },
-    { name = "evo-compute", specifier = ">=0.0.2" },
+    { name = "evo-compute", specifier = ">=0.0.4" },
     { name = "evo-files", specifier = ">=0.2.4" },
     { name = "evo-objects", specifier = ">=0.4.0" },
     { name = "evo-schemas", specifier = ">=2025.9.2" },


### PR DESCRIPTION
## Description

The SDK update moved kriging to `evo.compute.tasks.geostatistics.kriging` and swapped `RegionFilter` for the unified `Filter` API, which broke the MCP server on startup (import error).

This brings the kriging tools back in line with the SDK:

- fix the import path and switch to `source_filter` / `target_filter`
- keep the filters through the `build` → `run` round-trip (they were being dropped)
- support create-or-update targets, and fail fast with a clear message when the source attribute doesn't exist
- bump `evo-compute` to `0.0.4` and add a regression test

Jira: GSTAT-211

## Checklist

- [x] I have read the contributing guide and the code of conduct