### PR TITLE
POC to demo tool-search vs code-mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "An MCP server implementation using Evo SDK"
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
-    "fastmcp>=3.2.4",
+    "fastmcp[code-mode]>=3.2.4",
     "google-adk==1.28.1",
     "evo-files>=0.2.4",
     "evo-compute>=0.0.2",
@@ -29,6 +29,10 @@ dev = [
     "pre-commit>=4",
     "ruff==0.15.4",
     "reuse",
+]
+poc = [
+    "jupyterlab>=4",
+    "ipykernel>=6",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,5 +41,10 @@ line-length = 120
 [tool.ruff.lint]
 extend-select = ["I", "RUF022"]
 
+[tool.ruff.lint.per-file-ignores]
+# Notebook cells are intentionally self-contained: each re-imports what it needs
+# That triggers cross-cell redefinition warnings (F811) which are by design for a teaching notebook.
+"**/*.ipynb" = ["F811"]
+
 [tool.ruff.lint.isort]
 known-first-party = ["evo_mcp"]

--- a/src/mcp_tools.py
+++ b/src/mcp_tools.py
@@ -44,6 +44,7 @@ from evo_mcp.tools import (
     register_object_builder_tools,
     register_object_staging_tools,
 )
+from poc.tool_strategy import apply_strategy
 
 logger = logging.getLogger(__name__)
 OBJECTS_REFERENCE_UNAVAILABLE = "Objects reference information is currently unavailable."
@@ -155,6 +156,20 @@ if TOOL_FILTER in ["all", "compute"]:
         print("Evo MCP Server configured for Compute Agent")
     else:
         print("Evo MCP Server configured - Compute tools enabled")
+
+# =============================================================================
+# Tool-exposure strategy (applied AFTER all tools are registered)
+# =============================================================================
+# MCP_TOOL_STRATEGY selects how the LLM sees and reaches the tool catalog:
+#   - "none"        : full catalog listed upfront (default, current behavior)
+#   - "tool-search" : catalog hidden behind search_tools / call_tool
+#   - "code-mode"   : catalog hidden behind search / get_schema / execute (sandbox)
+# MCP_SEARCH_ENGINE ("bm25" | "regex") tunes the tool-search strategy.
+#
+# The strategy factory lives in the PoC package (src/poc) so the real
+# server shares the exact same wiring the PoC demonstrates.
+_applied_strategy = apply_strategy(mcp)
+print(f"Tool exposure strategy: {_applied_strategy.value}")
 
 # =============================================================================
 # Resources (not currently supported in ADK)

--- a/src/poc/__init__.py
+++ b/src/poc/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Bentley Systems, Incorporated
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared tool-exposure strategy factory used by the demo PoC and the real server."""

--- a/src/poc/demo_server.py
+++ b/src/poc/demo_server.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: 2026 Bentley Systems, Incorporated
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Self-contained PoC MCP server with mock Evo-flavored tools.
+
+The tools return canned data so reviewers can explore the three tool-exposure
+strategies (``none`` / ``tool-search`` / ``code-mode``) WITHOUT Evo credentials
+or network access. The point of the PoC is to observe *what the model sees* and
+*how it reaches the tools*, not to hit real Evo APIs.
+
+Run standalone (strategy from env)::
+
+    MCP_TOOL_STRATEGY=code-mode uv run python src/poc/demo_server.py
+
+Or build in-process for the notebook::
+
+    from demo_server import build_demo_server
+    mcp = build_demo_server("tool-search")
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make this folder importable (for `tool_strategy`) and the evo_mcp package importable
+# (for the notebook's live-server section, which registers the real Evo tools). This lets
+# the PoC run from any working directory. Layout: <repo>/src/poc/<this file>.
+_HERE = Path(__file__).resolve().parent
+_SRC = _HERE.parent  # <repo>/src
+for _p in (_HERE, _SRC):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from fastmcp import FastMCP  # noqa: E402  (import follows the sys.path shim above)
+from tool_strategy import (  # noqa: E402  (co-located strategy factory, shared with the real server)
+    SearchEngine,
+    ToolStrategy,
+    apply_strategy,
+)
+
+# ── Canned data ────────────────────────────────────────────────────────────────
+
+_WORKSPACES = [
+    {"id": "ws-001", "name": "Copper Ridge", "objects": 42},
+    {"id": "ws-002", "name": "Gold Valley", "objects": 17},
+    {"id": "ws-003", "name": "Iron Basin", "objects": 88},
+]
+
+_OBJECTS = {
+    "ws-001": [
+        {"id": "obj-a", "name": "collars", "schema": "downhole-collection", "size": 1200},
+        {"id": "obj-b", "name": "topography", "schema": "pointset", "size": 98000},
+        {"id": "obj-c", "name": "cu_grade", "schema": "pointset", "size": 45000},
+    ],
+    "ws-002": [
+        {"id": "obj-d", "name": "faults", "schema": "line-segments", "size": 300},
+    ],
+    "ws-003": [
+        {"id": "obj-e", "name": "block_model", "schema": "regular-block-model", "size": 5_000_000},
+    ],
+}
+
+_USERS = [
+    {"id": "u-1", "email": "geo@example.com", "role": "editor"},
+    {"id": "u-2", "email": "admin@example.com", "role": "owner"},
+]
+
+
+def register_demo_tools(mcp: FastMCP) -> None:
+    """Register a representative spread of read + write + admin tools.
+
+    Tags (``read`` / ``write`` / ``admin`` / ``compute``) mirror how the real
+    server could tag tools so a strategy can hide destructive tools from the
+    code/search path via a Visibility transform.
+    """
+
+    # ── Read tools ──────────────────────────────────────────────────────────
+    @mcp.tool(tags={"read"})
+    def list_workspaces() -> list[dict]:
+        """List all workspaces the caller can access."""
+        return _WORKSPACES
+
+    @mcp.tool(tags={"read"})
+    def get_workspace(workspace_id: str) -> dict:
+        """Get details for a single workspace by id."""
+        for ws in _WORKSPACES:
+            if ws["id"] == workspace_id:
+                return ws
+        raise ValueError(f"workspace {workspace_id!r} not found")
+
+    @mcp.tool(tags={"read"})
+    def list_objects(workspace_id: str, schema: str = "") -> list[dict]:
+        """List geoscience objects in a workspace, optionally filtered by schema."""
+        objs = _OBJECTS.get(workspace_id, [])
+        if schema:
+            objs = [o for o in objs if o["schema"] == schema]
+        return objs
+
+    @mcp.tool(tags={"read"})
+    def get_object(workspace_id: str, object_id: str) -> dict:
+        """Get metadata for a single object."""
+        for o in _OBJECTS.get(workspace_id, []):
+            if o["id"] == object_id:
+                return o
+        raise ValueError(f"object {object_id!r} not found")
+
+    @mcp.tool(tags={"read"})
+    def get_object_versions(workspace_id: str, object_id: str) -> list[dict]:
+        """List the version history of an object."""
+        return [
+            {"version": "v1", "created_at": "2026-01-02"},
+            {"version": "v2", "created_at": "2026-03-15"},
+        ]
+
+    @mcp.tool(tags={"read"})
+    def count_points(workspace_id: str, object_id: str) -> int:
+        """Return the number of points in a pointset-like object."""
+        for o in _OBJECTS.get(workspace_id, []):
+            if o["id"] == object_id:
+                return o["size"]
+        raise ValueError(f"object {object_id!r} not found")
+
+    @mcp.tool(tags={"read"})
+    def list_users() -> list[dict]:
+        """List users in the current instance."""
+        return _USERS
+
+    @mcp.tool(tags={"read"})
+    def workspace_health_check() -> dict:
+        """Report health of the workspace and object services."""
+        return {"workspace_service": "ok", "object_service": "ok"}
+
+    # ── Write tools ─────────────────────────────────────────────────────────
+    @mcp.tool(tags={"write"})
+    def create_workspace(name: str, description: str = "") -> dict:
+        """Create a new workspace."""
+        return {"id": "ws-new", "name": name, "description": description}
+
+    @mcp.tool(tags={"write"})
+    def create_pointset(workspace_id: str, name: str, points: list) -> dict:
+        """Create a pointset object from a list of XYZ points."""
+        return {"id": "obj-new", "name": name, "point_count": len(points)}
+
+    @mcp.tool(tags={"write"})
+    def upload_file(workspace_id: str, local_path: str, target_path: str = "") -> dict:
+        """Upload a file into a workspace's file store."""
+        return {"path": target_path or local_path, "status": "uploaded"}
+
+    # ── Compute tools ───────────────────────────────────────────────────────
+    @mcp.tool(tags={"compute"})
+    def kriging_run(workspace_id: str, object_id: str, variogram: dict) -> dict:
+        """Run a kriging estimation job and return a job handle."""
+        return {"job_id": "job-123", "status": "queued"}
+
+    # ── Admin / destructive tools ───────────────────────────────────────────
+    @mcp.tool(tags={"admin", "destructive"})
+    def delete_object(workspace_id: str, object_id: str) -> dict:
+        """Permanently delete an object. Destructive."""
+        return {"id": object_id, "deleted": True}
+
+    @mcp.tool(tags={"admin", "destructive"})
+    def remove_user(user_id: str) -> dict:
+        """Remove a user from the instance. Destructive."""
+        return {"id": user_id, "removed": True}
+
+    @mcp.tool(tags={"admin"})
+    def update_user_role(user_id: str, role: str) -> dict:
+        """Change a user's role in the instance."""
+        return {"id": user_id, "role": role}
+
+
+def build_demo_server(
+    strategy: ToolStrategy | str | None = None,
+    *,
+    search_engine: SearchEngine | str | None = None,
+    max_results: int = 5,
+    always_visible: list[str] | None = None,
+) -> FastMCP:
+    """Build a demo server with tools registered and a strategy applied.
+
+    Args:
+        strategy: ``none`` / ``tool-search`` / ``code-mode``. Defaults to the
+            ``MCP_TOOL_STRATEGY`` env var when ``None``.
+        search_engine: ``bm25`` / ``regex`` for the tool-search strategy.
+        max_results: Max results per search (tool-search only).
+        always_visible: Tool names to keep pinned in ``list_tools``.
+    """
+    if isinstance(strategy, str):
+        strategy = ToolStrategy(strategy)
+    if isinstance(search_engine, str):
+        search_engine = SearchEngine(search_engine)
+
+    mcp = FastMCP("Evo MCP PoC")
+    register_demo_tools(mcp)
+    applied = apply_strategy(
+        mcp,
+        strategy,
+        search_engine=search_engine,
+        max_results=max_results,
+        always_visible=always_visible,
+    )
+    mcp.instructions = f"Evo MCP PoC demo server (tool strategy: {applied.value})."
+    return mcp
+
+
+if __name__ == "__main__":
+    # Strategy chosen from MCP_TOOL_STRATEGY / MCP_SEARCH_ENGINE env vars.
+    build_demo_server().run()

--- a/src/poc/explore.ipynb
+++ b/src/poc/explore.ipynb
@@ -1,0 +1,1097 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e5ee601d",
+   "metadata": {},
+   "source": [
+    "# Scalable MCP tooling — interactive PoC\n",
+    "\n",
+    "Compare the three **tool-exposure strategies** for the Evo MCP server and *observe exactly what the model sees*:\n",
+    "\n",
+    "| Strategy | `list_tools()` returns | Mechanism |\n",
+    "|---|---|---|\n",
+    "| `none` | the full catalog (15 demo tools) | today's behavior |\n",
+    "| `tool-search` | `search_tools`, `call_tool` | FastMCP Tool Search transform |\n",
+    "| `code-mode` | `search`, `get_schema`, `execute` | FastMCP Code Mode transform (sandbox) |\n",
+    "\n",
+    "This notebook uses a **self-contained demo server** (`demo_server.py`) with mock Evo-flavored\n",
+    "tools that return canned data — **no Evo credentials or network needed**. The same\n",
+    "`apply_strategy()` factory used here is wired into the real server (`src/mcp_tools.py`) behind\n",
+    "the `MCP_TOOL_STRATEGY` env var, so what you see here is the real production wiring.\n",
+    "\n",
+    "> Run with: `uv run --extra poc jupyter lab` from the repo root.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e81c6639",
+   "metadata": {},
+   "source": [
+    "## 0. Setup\n",
+    "We talk to the in-memory server with a FastMCP `Client` — the same interface a real MCP client/LLM uses. `list_tools()` is *literally* what the model receives in its context."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5d960689",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T21:09:28.266926Z",
+     "iopub.status.busy": "2026-07-08T21:09:28.266841Z",
+     "iopub.status.idle": "2026-07-08T21:09:29.027575Z",
+     "shell.execute_reply": "2026-07-08T21:09:29.026972Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "from demo_server import build_demo_server\n",
+    "from fastmcp import Client\n",
+    "\n",
+    "\n",
+    "def show(obj, n=2000):\n",
+    "    s = json.dumps(obj, indent=2, default=str)\n",
+    "    print(s if len(s) <= n else s[:n] + f\"\\n... [{len(s) - n} more chars]\")\n",
+    "\n",
+    "\n",
+    "async def list_visible(strategy, **kw):\n",
+    "    mcp = build_demo_server(strategy, **kw)\n",
+    "    async with Client(mcp) as c:\n",
+    "        tools = await c.list_tools()\n",
+    "        return [t.name for t in tools]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4f78478",
+   "metadata": {},
+   "source": [
+    "## 1. What the model sees upfront (`list_tools`)\n",
+    "This is the token cost paid **before the user's request is even read**. Watch it collapse from 15 tools to 2–3 synthetic tools."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "15a8421f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T21:09:29.029081Z",
+     "iopub.status.busy": "2026-07-08T21:09:29.028990Z",
+     "iopub.status.idle": "2026-07-08T21:09:29.059056Z",
+     "shell.execute_reply": "2026-07-08T21:09:29.058656Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "none         -> 15 tools: ['list_workspaces', 'get_workspace', 'list_objects', 'get_object', 'get_object_versions', 'count_points', 'list_users', 'workspace_health_check', 'create_workspace', 'create_pointset', 'upload_file', 'kriging_run', 'delete_object', 'remove_user', 'update_user_role']\n",
+      "tool-search  -> 2 tools: ['search_tools', 'call_tool']\n",
+      "code-mode    -> 3 tools: ['search', 'get_schema', 'execute']\n"
+     ]
+    }
+   ],
+   "source": [
+    "for strategy in [\"none\", \"tool-search\", \"code-mode\"]:\n",
+    "    names = await list_visible(strategy)\n",
+    "    print(f\"{strategy:12} -> {len(names)} tools: {names}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72b630e4",
+   "metadata": {},
+   "source": [
+    "### 1a. Approximate context cost of the upfront catalog\n",
+    "The real cost isn't the tool *count* — it's the serialized schema (names + descriptions + params) shipped every turn. Let's measure the full listing for each strategy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "efe6c5c6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T21:09:29.060177Z",
+     "iopub.status.busy": "2026-07-08T21:09:29.060119Z",
+     "iopub.status.idle": "2026-07-08T21:09:29.082382Z",
+     "shell.execute_reply": "2026-07-08T21:09:29.082027Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "none         -> 15 tools, ~ 7257 chars of schema (~1814 tokens) listed upfront\n",
+      "tool-search  ->  2 tools, ~ 1316 chars of schema (~329 tokens) listed upfront\n",
+      "code-mode    ->  3 tools, ~ 2527 chars of schema (~631 tokens) listed upfront\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def listing_size(strategy, **kw):\n",
+    "    mcp = build_demo_server(strategy, **kw)\n",
+    "    async with Client(mcp) as c:\n",
+    "        tools = await c.list_tools()\n",
+    "        payload = [t.model_dump() for t in tools]\n",
+    "    return len(tools), len(json.dumps(payload, default=str))\n",
+    "\n",
+    "\n",
+    "for strategy in [\"none\", \"tool-search\", \"code-mode\"]:\n",
+    "    count, chars = await listing_size(strategy)\n",
+    "    print(f\"{strategy:12} -> {count:2} tools, ~{chars:5} chars of schema (~{chars // 4} tokens) listed upfront\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0fb62cdd",
+   "metadata": {},
+   "source": [
+    "## 2. Strategy `none` — the baseline\n",
+    "Every tool is visible; the model calls one, gets the raw result back into context, reasons, calls the next. Simple and deterministic, but the catalog and every intermediate result flow through the context window."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7694ecf9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T21:09:29.083518Z",
+     "iopub.status.busy": "2026-07-08T21:09:29.083449Z",
+     "iopub.status.idle": "2026-07-08T21:09:29.095544Z",
+     "shell.execute_reply": "2026-07-08T21:09:29.095197Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Visible tools: ['list_workspaces', 'get_workspace', 'list_objects', 'get_object', 'get_object_versions', 'count_points', 'list_users', 'workspace_health_check', 'create_workspace', 'create_pointset', 'upload_file', 'kriging_run', 'delete_object', 'remove_user', 'update_user_role']\n",
+      "\n",
+      "Step 1 list_workspaces ->\n",
+      "[\n",
+      "  {\n",
+      "    \"id\": \"ws-001\",\n",
+      "    \"name\": \"Copper Ridge\",\n",
+      "    \"objects\": 42\n",
+      "  },\n",
+      "  {\n",
+      "    \"id\": \"ws-002\",\n",
+      "    \"name\": \"Gold Valley\",\n",
+      "    \"objects\": 17\n",
+      "  },\n",
+      "  {\n",
+      "    \"id\": \"ws-003\",\n",
+      "    \"name\": \"Iron Basin\",\n",
+      "    \"objects\": 88\n",
+      "  }\n",
+      "]\n",
+      "Step 2 list_objects(ws-001) ->\n",
+      "[\n",
+      "  {\n",
+      "    \"id\": \"obj-a\",\n",
+      "    \"name\": \"collars\",\n",
+      "    \"schema\": \"downhole-collection\",\n",
+      "    \"size\": 1200\n",
+      "  },\n",
+      "  {\n",
+      "    \"id\": \"obj-b\",\n",
+      "    \"name\": \"topography\",\n",
+      "    \"schema\": \"pointset\",\n",
+      "    \"size\": 98000\n",
+      "  },\n",
+      "  {\n",
+      "    \"id\": \"obj-c\",\n",
+      "    \"name\": \"cu_grade\",\n",
+      "    \"schema\": \"pointset\",\n",
+      "    \"size\": 45000\n",
+      "  }\n",
+      "]\n"
+     ]
+    }
+   ],
+   "source": [
+    "mcp = build_demo_server(\"none\")\n",
+    "async with Client(mcp) as c:\n",
+    "    tools = await c.list_tools()\n",
+    "    print(\"Visible tools:\", [t.name for t in tools])\n",
+    "    print()\n",
+    "    # A 2-step workflow = 2 separate round-trips, 2 raw results in context.\n",
+    "    ws = (await c.call_tool(\"list_workspaces\", {})).data\n",
+    "    print(\"Step 1 list_workspaces ->\")\n",
+    "    show(ws)\n",
+    "    objs = (await c.call_tool(\"list_objects\", {\"workspace_id\": \"ws-001\"})).data\n",
+    "    print(\"Step 2 list_objects(ws-001) ->\")\n",
+    "    show(objs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f428c653",
+   "metadata": {},
+   "source": [
+    "## 3. Strategy `tool-search` — discovery on demand\n",
+    "`list_tools()` returns only `search_tools` + `call_tool`. The model **searches** for what it needs\n",
+    "(full schema returned inline, ranked by BM25), then invokes via the `call_tool` proxy.\n",
+    "\n",
+    "Solves: *too many tools upfront*. Does **not** solve round-trips or intermediate-result pollution —\n",
+    "each discovered tool is still a normal call whose raw result lands in context."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "502b21c1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T21:09:29.096532Z",
+     "iopub.status.busy": "2026-07-08T21:09:29.096476Z",
+     "iopub.status.idle": "2026-07-08T21:09:29.107304Z",
+     "shell.execute_reply": "2026-07-08T21:09:29.106947Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Visible tools: ['search_tools', 'call_tool']\n",
+      "\n",
+      "search_tools('objects in a workspace') -> ranked:\n",
+      "    list_objects - List geoscience objects in a workspace, optionally filtered by schema.\n",
+      "    list_users - List users in the current instance.\n",
+      "    count_points - Return the number of points in a pointset-like object.\n",
+      "    update_user_role - Change a user's role in the instance.\n",
+      "    get_workspace - Get details for a single workspace by id.\n",
+      "\n",
+      "Full schema of top hit (this is what the model sees to build the call):\n",
+      "{\n",
+      "  \"name\": \"list_objects\",\n",
+      "  \"description\": \"List geoscience objects in a workspace, optionally filtered by schema.\",\n",
+      "  \"inputSchema\": {\n",
+      "    \"additionalProperties\": false,\n",
+      "    \"properties\": {\n",
+      "      \"workspace_id\": {\n",
+      "        \"type\": \"string\"\n",
+      "      },\n",
+      "      \"schema\": {\n",
+      "        \"default\": \"\",\n",
+      "        \"type\": \"string\"\n",
+      "      }\n",
+      "    },\n",
+      "    \"required\": [\n",
+      "      \"workspace_id\"\n",
+      "    ],\n",
+      "    \"type\": \"object\"\n",
+      "  },\n",
+      "  \"outputSchema\": {\n",
+      "    \"properties\": {\n",
+      "      \"result\": {\n",
+      "        \"items\": {\n",
+      "          \"additionalProperties\": true,\n",
+      "          \"type\": \"object\"\n",
+      "        },\n",
+      "        \"type\": \"array\"\n",
+      "      }\n",
+      "    },\n",
+      "    \"required\": [\n",
+      "      \"result\"\n",
+      "    ],\n",
+      "    \"type\": \"object\",\n",
+      "    \"x-fastmcp-wrap-result\": true\n",
+      "  },\n",
+      "  \"meta\": {\n",
+      "    \"fastmcp\": {\n",
+      "      \"tags\": [\n",
+      "        \"read\"\n",
+      "      ]\n",
+      "    }\n",
+      "  }\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "mcp = build_demo_server(\"tool-search\")  # engine defaults to bm25\n",
+    "async with Client(mcp) as c:\n",
+    "    print(\"Visible tools:\", [t.name for t in (await c.list_tools())])\n",
+    "    print()\n",
+    "    # Discover\n",
+    "    hits = (await c.call_tool(\"search_tools\", {\"query\": \"objects in a workspace\"})).data\n",
+    "    print(\"search_tools('objects in a workspace') -> ranked:\")\n",
+    "    for t in hits:\n",
+    "        print(\"   \", t[\"name\"], \"-\", t[\"description\"])\n",
+    "    print()\n",
+    "    # Inspect the full schema the model would receive for the top hit\n",
+    "    print(\"Full schema of top hit (this is what the model sees to build the call):\")\n",
+    "    show(hits[0], 900)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6a9c1e3a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T21:09:29.108214Z",
+     "iopub.status.busy": "2026-07-08T21:09:29.108158Z",
+     "iopub.status.idle": "2026-07-08T21:09:29.119242Z",
+     "shell.execute_reply": "2026-07-08T21:09:29.118955Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "call_tool(list_objects) ->\n",
+      "[\n",
+      "  {\n",
+      "    \"id\": \"obj-b\",\n",
+      "    \"name\": \"topography\",\n",
+      "    \"schema\": \"pointset\",\n",
+      "    \"size\": 98000\n",
+      "  },\n",
+      "  {\n",
+      "    \"id\": \"obj-c\",\n",
+      "    \"name\": \"cu_grade\",\n",
+      "    \"schema\": \"pointset\",\n",
+      "    \"size\": 45000\n",
+      "  }\n",
+      "]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Invoke a discovered tool through the call_tool proxy\n",
+    "async with Client(build_demo_server(\"tool-search\")) as c:\n",
+    "    res = (\n",
+    "        await c.call_tool(\n",
+    "            \"call_tool\", {\"name\": \"list_objects\", \"arguments\": {\"workspace_id\": \"ws-001\", \"schema\": \"pointset\"}}\n",
+    "        )\n",
+    "    ).data\n",
+    "    print(\"call_tool(list_objects) ->\")\n",
+    "    show(res)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "880adcb7",
+   "metadata": {},
+   "source": [
+    "### 3a. Regex engine vs BM25\n",
+    "`tool-search` supports two engines. BM25 ranks by natural-language relevance; regex does deterministic pattern matching. Choose via `MCP_SEARCH_ENGINE` / the `search_engine=` argument."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "341441ea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T21:09:29.120323Z",
+     "iopub.status.busy": "2026-07-08T21:09:29.120264Z",
+     "iopub.status.idle": "2026-07-08T21:09:29.140740Z",
+     "shell.execute_reply": "2026-07-08T21:09:29.140375Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BM25  'delete something': ['delete_object']\n",
+      "Regex '^(delete|remove)': ['delete_object', 'remove_user']\n"
+     ]
+    }
+   ],
+   "source": [
+    "async with Client(build_demo_server(\"tool-search\", search_engine=\"bm25\")) as c:\n",
+    "    print(\n",
+    "        \"BM25  'delete something':\",\n",
+    "        [t[\"name\"] for t in (await c.call_tool(\"search_tools\", {\"query\": \"delete something\"})).data],\n",
+    "    )\n",
+    "\n",
+    "async with Client(build_demo_server(\"tool-search\", search_engine=\"regex\")) as c:\n",
+    "    # regex uses a `pattern` argument, not `query`\n",
+    "    print(\n",
+    "        \"Regex '^(delete|remove)':\",\n",
+    "        [t[\"name\"] for t in (await c.call_tool(\"search_tools\", {\"pattern\": \"^(delete|remove)\"})).data],\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2816e8cc",
+   "metadata": {},
+   "source": [
+    "## 4. Strategy `code-mode` — orchestrate in a sandbox\n",
+    "`list_tools()` returns `search`, `get_schema`, `execute`. The model discovers tools, then writes\n",
+    "**Python** that chains `await call_tool(name, params)` calls in a sandbox and returns only the final\n",
+    "answer. Intermediate results never touch the context window.\n",
+    "\n",
+    "Solves: *too many tools upfront* **and** *round-trips* **and** *intermediate-result pollution*.\n",
+    "Cost: the model must write correct code (non-deterministic); needs a sandbox (`fastmcp[code-mode]`).\n",
+    "\n",
+    "Inside the sandbox, `call_tool(name, params)` is the **only** function available — no client, no\n",
+    "token, no network, no imports. That is the key cloud-safety property."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3c227c83",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T21:09:29.141801Z",
+     "iopub.status.busy": "2026-07-08T21:09:29.141747Z",
+     "iopub.status.idle": "2026-07-08T21:09:29.152309Z",
+     "shell.execute_reply": "2026-07-08T21:09:29.151882Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Visible tools: ['search', 'get_schema', 'execute']\n",
+      "\n",
+      "search('workspace objects') ->\n",
+      "11 of 15 tools:\n",
+      "\n",
+      "- list_objects: List geoscience objects in a workspace, optionally filtered by schema.\n",
+      "- create_pointset: Create a pointset object from a list of XYZ points.\n",
+      "- count_points: Return the number of points in a pointset-like object.\n",
+      "- get_workspace: Get details for a single workspace by id.\n",
+      "- create_workspace: Create a new workspace.\n",
+      "- workspace_health_check: Report health of the workspace and object services.\n",
+      "- upload_file: Upload a file into a workspace's file store.\n",
+      "- get_object: Get metadata for a single object.\n",
+      "- delete_object: Permanently delete an object. Destructive.\n",
+      "- get_object_versions: List the version history of an object.\n",
+      "- kriging_run: Run a kriging estimation job and return a job handle.\n"
+     ]
+    }
+   ],
+   "source": [
+    "mcp = build_demo_server(\"code-mode\")\n",
+    "async with Client(mcp) as c:\n",
+    "    print(\"Visible tools:\", [t.name for t in (await c.list_tools())])\n",
+    "    print()\n",
+    "    # Stage 1: search\n",
+    "    print(\"search('workspace objects') ->\")\n",
+    "    print((await c.call_tool(\"search\", {\"query\": \"workspace objects points\"})).data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "a83ac250",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T21:09:29.153243Z",
+     "iopub.status.busy": "2026-07-08T21:09:29.153166Z",
+     "iopub.status.idle": "2026-07-08T21:09:29.181035Z",
+     "shell.execute_reply": "2026-07-08T21:09:29.180683Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "execute(workflow) -> single final answer returned to the model:\n",
+      "{\n",
+      "  \"pointsets\": 2,\n",
+      "  \"total_points\": 143000\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Stage 2 + 3: get_schema then execute a multi-step workflow in ONE round-trip.\n",
+    "# Task: total points across all pointsets in ws-001 — 1 list + N counts, folded server-side.\n",
+    "workflow = \"\"\"\n",
+    "objs = (await call_tool(\"list_objects\", {\"workspace_id\": \"ws-001\", \"schema\": \"pointset\"}))[\"result\"]\n",
+    "total = 0\n",
+    "for o in objs:\n",
+    "    r = await call_tool(\"count_points\", {\"workspace_id\": \"ws-001\", \"object_id\": o[\"id\"]})\n",
+    "    total += r[\"result\"]\n",
+    "return {\"pointsets\": len(objs), \"total_points\": total}\n",
+    "\"\"\"\n",
+    "async with Client(build_demo_server(\"code-mode\")) as c:\n",
+    "    result = (await c.call_tool(\"execute\", {\"code\": workflow})).data\n",
+    "    print(\"execute(workflow) -> single final answer returned to the model:\")\n",
+    "    show(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86196df2",
+   "metadata": {},
+   "source": [
+    "Note the payoff: the loop above would be **1 + N** separate tool calls (and N raw result blobs in\n",
+    "context) under `none` or `tool-search`. Under `code-mode` the model sees **one** call and **one**\n",
+    "small result. `call_tool` inside the sandbox returns `{'result': <value>}` — hence the `[\"result\"]`\n",
+    "unwrapping."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed6df77a",
+   "metadata": {},
+   "source": [
+    "## 5. Guardrails: hiding destructive tools from the code/search path\n",
+    "Both transforms respect the FastMCP auth/visibility pipeline. Tools are tagged\n",
+    "(`read` / `write` / `admin` / `destructive`) in `demo_server.py`. A `Visibility` transform applied\n",
+    "*before* the strategy removes destructive tools from discovery entirely — so they can't be reached\n",
+    "via `search`/`execute`/`call_tool`, while remaining available as explicit, confirmable direct calls."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "9010dc5e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T21:09:29.182104Z",
+     "iopub.status.busy": "2026-07-08T21:09:29.182040Z",
+     "iopub.status.idle": "2026-07-08T21:09:29.193526Z",
+     "shell.execute_reply": "2026-07-08T21:09:29.193188Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Guarded tool-search for 'delete remove object user' -> ['update_user_role', 'get_object', 'get_object_versions', 'count_points', 'workspace_health_check']\n",
+      "(delete_object / remove_user are absent — hidden from discovery)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from demo_server import register_demo_tools\n",
+    "from fastmcp import FastMCP\n",
+    "from fastmcp.server.transforms import Visibility\n",
+    "from tool_strategy import ToolStrategy, apply_strategy\n",
+    "\n",
+    "\n",
+    "def build_guarded(strategy):\n",
+    "    mcp = FastMCP(\"Evo MCP PoC (guarded)\")\n",
+    "    register_demo_tools(mcp)\n",
+    "    mcp.add_transform(Visibility(False, tags={\"destructive\"}))  # hide destructive tools first\n",
+    "    apply_strategy(mcp, ToolStrategy(strategy))\n",
+    "    return mcp\n",
+    "\n",
+    "\n",
+    "async with Client(build_guarded(\"tool-search\")) as c:\n",
+    "    hits = [t[\"name\"] for t in (await c.call_tool(\"search_tools\", {\"query\": \"delete remove object user\"})).data]\n",
+    "    print(\"Guarded tool-search for 'delete remove object user' ->\", hits)\n",
+    "    print(\"(delete_object / remove_user are absent — hidden from discovery)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "febfae22",
+   "metadata": {},
+   "source": [
+    "## 6. Against the live Evo MCP server (discovery only)\n",
+    "\n",
+    "Everything above used the mock **demo server**. This section targets the **real Evo MCP tool\n",
+    "catalog** — every tool registered by `src/mcp_tools.py` (~46 tools).\n",
+    "\n",
+    "**Safety & scope.** We exercise **discovery/search only**: `list_tools`, `search_tools`, `search`,\n",
+    "`get_schema`. These merely *read the tool catalog* — they make **no Evo API calls and need no\n",
+    "credentials**. We deliberately do **not** call `call_tool` or run `execute` against Evo here; those\n",
+    "would hit a live tenant. The multi-step workflow is **presented** as the code the model *would* write,\n",
+    "not executed.\n",
+    "\n",
+    "This is the convincing headline for the team: our **real** catalog collapsing from ~46 tools to 2–3\n",
+    "synthetic tools."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "ee831700",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T21:09:29.194565Z",
+     "iopub.status.busy": "2026-07-08T21:09:29.194503Z",
+     "iopub.status.idle": "2026-07-08T21:09:29.884558Z",
+     "shell.execute_reply": "2026-07-08T21:09:29.884022Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Build the real Evo tool catalog under a chosen strategy — mirrors src/mcp_tools.py's\n",
+    "# \"all\" tool-filter registration, but parametrized so we can compare strategies side by side.\n",
+    "# Registration is just decorators: no auth, no network.\n",
+    "from fastmcp import FastMCP\n",
+    "from tool_strategy import ToolStrategy, apply_strategy\n",
+    "\n",
+    "from evo_mcp.tools import (\n",
+    "    register_admin_tools,\n",
+    "    register_compute_tools,\n",
+    "    register_file_tools,\n",
+    "    register_filesystem_tools,\n",
+    "    register_general_tools,\n",
+    "    register_instance_users_admin_tools,\n",
+    "    register_object_builder_tools,\n",
+    "    register_object_staging_tools,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def build_live_server(strategy):\n",
+    "    \"\"\"Fresh server with the *real* Evo tools registered and a strategy applied.\"\"\"\n",
+    "    mcp = FastMCP(\"Evo MCP Server\")\n",
+    "    register_general_tools(mcp)\n",
+    "    register_admin_tools(mcp)\n",
+    "    register_instance_users_admin_tools(mcp)\n",
+    "    register_filesystem_tools(mcp)\n",
+    "    register_object_builder_tools(mcp)\n",
+    "    register_file_tools(mcp)\n",
+    "    register_compute_tools(mcp)\n",
+    "    register_object_staging_tools(mcp)\n",
+    "    apply_strategy(mcp, ToolStrategy(strategy))\n",
+    "    return mcp\n",
+    "\n",
+    "\n",
+    "async def live_listing_size(strategy):\n",
+    "    mcp = build_live_server(strategy)\n",
+    "    async with Client(mcp) as c:\n",
+    "        tools = await c.list_tools()\n",
+    "        payload = [t.model_dump() for t in tools]\n",
+    "    return len(tools), len(json.dumps(payload, default=str))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "968775c5",
+   "metadata": {},
+   "source": [
+    "### 6a. The real catalog collapse\n",
+    "Same measurement as §1a, but against the **actual Evo tool catalog**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "6c693dd1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T21:09:29.885863Z",
+     "iopub.status.busy": "2026-07-08T21:09:29.885714Z",
+     "iopub.status.idle": "2026-07-08T21:09:29.959484Z",
+     "shell.execute_reply": "2026-07-08T21:09:29.959176Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "strategy       upfront tools  schema chars   ~tokens\n",
+      "----------------------------------------------------\n",
+      "none                      42         54265     13566\n",
+      "tool-search                2          1316       329\n",
+      "code-mode                  3          2527       631\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{'strategy':14}{'upfront tools':>14}{'schema chars':>14}{'~tokens':>10}\")\n",
+    "print(\"-\" * 52)\n",
+    "for strat in [\"none\", \"tool-search\", \"code-mode\"]:\n",
+    "    count, chars = await live_listing_size(strat)\n",
+    "    print(f\"{strat:14}{count:>14}{chars:>14}{chars // 4:>10}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6e60ed8",
+   "metadata": {},
+   "source": [
+    "### 6b. Live discovery — `tool-search`\n",
+    "Real natural-language queries against the real tool names. Safe: `search_tools` only reads the\n",
+    "catalog. (We stop at discovery — no `call_tool`.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "2a2d8668",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T21:09:29.960721Z",
+     "iopub.status.busy": "2026-07-08T21:09:29.960664Z",
+     "iopub.status.idle": "2026-07-08T21:09:30.001740Z",
+     "shell.execute_reply": "2026-07-08T21:09:30.001470Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "search_tools('objects in a workspace') -> ['list_objects', 'preview_duplicate_scan', 'kriging_run', 'create_workspace_snapshot', 'find_duplicate_objects']\n",
+      "search_tools('kriging estimation') -> ['kriging_run', 'kriging_build_parameters']\n",
+      "search_tools('download a file version') -> ['download_file', 'workspace_copy_object', 'get_object', 'preview_csv_file', 'list_file_versions']\n",
+      "search_tools('manage users and roles') -> ['get_users_in_instance', 'add_users_to_instance', 'update_user_role_in_instance', 'list_roles_in_instance', 'remove_user_from_instance']\n",
+      "\n",
+      "Full schema of top hit (what the model uses to build the call):\n",
+      "{\n",
+      "  \"name\": \"kriging_run\",\n",
+      "  \"description\": \"Run one or more kriging compute tasks in parallel.\",\n",
+      "  \"inputSchema\": {\n",
+      "    \"additionalProperties\": false,\n",
+      "    \"properties\": {\n",
+      "      \"workspace_id\": {\n",
+      "        \"type\": \"string\",\n",
+      "        \"description\": \"Workspace UUID where all tasks should run.\"\n",
+      "      },\n",
+      "      \"scenarios\": {\n",
+      "        \"items\": {\n",
+      "          \"description\": \"Parameters for the kriging task.\\n\\nDefines all inputs needed to run a kriging interpolation task.\\n\\nExample:\\n    >>> from evo.compute.tasks import run, SearchNeighborhood, Ellipsoid, EllipsoidRanges\\n    >>> from evo.compute.tasks.kriging import KrigingParameters, RegionFilter\\n    >>>\\n    >>> params = KrigingParameters(\\n    ...     source=pointset.attributes[\\\"grade\\\"],  # Source attribute\\n    ...     target=block_model.attributes[\\\"kriged_grade\\\"],  # Target attribute (creates if doesn't exist)\\n    ...     variogram=variogram,  # Variogram model\\n    ...     search=SearchNeighborhood(\\n    ...         ellipsoid=Ellipso\n",
+      "... [12636 more chars]\n"
+     ]
+    }
+   ],
+   "source": [
+    "async with Client(build_live_server(\"tool-search\")) as c:\n",
+    "    for q in [\"objects in a workspace\", \"kriging estimation\", \"download a file version\", \"manage users and roles\"]:\n",
+    "        hits = (await c.call_tool(\"search_tools\", {\"query\": q})).data\n",
+    "        print(f\"search_tools({q!r}) -> {[t['name'] for t in hits]}\")\n",
+    "    print()\n",
+    "    # The full schema the model would receive for one real tool:\n",
+    "    top = (await c.call_tool(\"search_tools\", {\"query\": \"kriging estimation\"})).data[0]\n",
+    "    print(\"Full schema of top hit (what the model uses to build the call):\")\n",
+    "    show(top, 1000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab5ee99d",
+   "metadata": {},
+   "source": [
+    "### 6c. Live discovery — `code-mode`\n",
+    "`search` then `get_schema` against the real catalog. Both are catalog reads — no Evo API calls.\n",
+    "We intentionally **do not call `execute`** here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "8dfb5f9d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T21:09:30.002893Z",
+     "iopub.status.busy": "2026-07-08T21:09:30.002839Z",
+     "iopub.status.idle": "2026-07-08T21:09:30.034581Z",
+     "shell.execute_reply": "2026-07-08T21:09:30.034219Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "search('workspace objects and versions'):\n",
+      "34 of 42 tools:\n",
+      "\n",
+      "- create_workspace_snapshot: Create a snapshot of all objects and their current versions in a workspace.\n",
+      "- list_file_versions: List all versions of a file in a workspace.\n",
+      "- preview_duplicate_scan: Preview workspaces and object counts before running a duplicate scan.\n",
+      "\n",
+      "Lists all workspaces in the current instance with the number of objects\n",
+      "in each. Use this to decide which workspaces to include in a\n",
+      "`find_duplicate_objects` call. No objects are downloaded.\n",
+      "\n",
+      "Returns:\n",
+      "    A dict with:\n",
+      "      - total_workspaces: number of workspaces in the instance\n",
+      "      - workspaces: list of {workspace_id, workspace_name, object_count}\n",
+      "        (object_count is -1 if listing failed for that workspace)\n",
+      "- list_objects: List objects in a workspace with optional filtering.\n",
+      "- workspace_duplicate_workspace: Duplicate entire workspace (all objects and data blobs).\n",
+      "- find_duplicate_objects: Find duplicate objects across Evo workspaces by comparing blob hashes.\n",
+      "\n",
+      "Scans objects in the selected workspaces, fetches their data-blob references,\n",
+      "and reports pairs of objects that share one or more blob hashes. This helps\n",
+      "identify copied or redundant data.\n",
+      "\n",
+      "You can scope the analysis to specific workspaces or run it across the\n",
+      "entire instance. Provide either workspace_ids or workspace_names (not both).\n",
+      "\n",
+      "When neither workspace_ids nor workspace_names is provided, the tool will\n",
+      "scan up to `max_workspaces` workspaces. If the instance has more workspaces\n",
+      "than the limit, the tool returns the full workspace list so you can select\n",
+      "specific workspaces to scan. Set `scan_all_workspaces=True` to override\n",
+      "this safety limit and scan every workspace (may be very slow).\n",
+      "\n",
+      "Use `preview_duplicate_scan` first to see workspace names and object counts\n",
+      "before committing to a full scan.\n",
+      "- compare_evo_objects_detailed: Compare two Evo objects in detail, including linked Parquet metadata.\n",
+      "\n",
+      "Each side can point to either the current instance or a specific alternate\n",
+      "instance. The tool resolves the object, compares its JSON payload, then\n",
+      "downloads each linked Parquet blob from `links.data` and reports schema and\n",
+      "format metadata.\n",
+      "- staging_discard_object: Remove a locally staged object from the session.\n",
+      "\n",
+      "Discards the staged payload and deregisters the object by name.\n",
+      "This does not affect any published Evo objects.\n",
+      "- kriging_run: Run one or more kriging compute tasks in parallel.\n",
+      "- get_workspace_summary: Get summary statistics for a workspace (object counts by type and file counts by extension).\n",
+      "- kriging_build_parameters: Build a validated kriging payload from primitive inputs.\n",
+      "- viewer_generate_multi_object_links: Generate portal and viewer links for an explicit user-supplied object list.\n",
+      "- build_and_create_pointset: Build and create a Pointset object from a CSV file.\n",
+      "\n",
+      "A Pointset is a set of points in 3D space with optional attributes.\n",
+      "Common uses: sample locations, sensor positions, survey points.\n",
+      "- build_and_create_downhole_intervals: Build and create a DownholeIntervals object from a CSV file.\n",
+      "\n",
+      "A DownholeIntervals object represents downhole intervals with pre-computed\n",
+      "3D coordinates for start, end, and midpoint of each interval.\n",
+      "Common uses: composited assay data, geological intervals with desurvey applied.\n",
+      "\n",
+      "Unlike DownholeCollection (which stores collar + survey data), this format\n",
+      "stores the final computed coordinates for each interval directly.\n",
+      "- build_and_create_downhole_collection: Build and create a DownholeCollection object from CSV files.\n",
+      "\n",
+      "This is a high-level tool that:\n",
+      "1. Reads and validates all CSV files\n",
+      "2. Constructs the complete object with proper schema structure\n",
+      "3. Uploads all data blobs (parquet files)\n",
+      "4. Validates the final object against the schema\n",
+      "5. Creates the object in the workspace (if not dry_run)\n",
+      "- build_and_create_line_segments: Build and create a LineSegments object from CSV files.\n",
+      "\n",
+      "A LineSegments object is a collection of line segments in 3D space.\n",
+      "Common uses: fault traces, geological contacts, survey lines.\n",
+      "\n",
+      "Requires two CSV files:\n",
+      "- vertices_file: Contains X/Y/Z coordinates for each vertex (row 0 = vertex index 0)\n",
+      "- segments_file: Contains start/end vertex indices defining each segment\n",
+      "- get_workspace: Get workspace details by ID or name.\n",
+      "- create_workspace: Create a new workspace.\n",
+      "- workspace_copy_object: Copy a single object from one workspace to another, including data blobs.\n",
+      "- workspace_health_check: Check health status of Evo services.\n",
+      "- staging_list_interactions: List all interactions available for a staged object type.\n",
+      "\n",
+      "Returns each interaction name, description, and accepted parameters.\n",
+      "Use ``staging_invoke_interaction`` to call any listed interaction on a\n",
+      "staged object by name.\n",
+      "- upload_file: Upload a local file to a workspace.\n",
+      "- list_files: List all files in a workspace.\n",
+      "- download_file: Download a file from a workspace to the local data directory.\n",
+      "- staging_create_object: Create a new staged object of the given type.\n",
+      "\n",
+      "Each object type has a single create path. Use ``staging_list_object_types``\n",
+      "to discover valid types and ``staging_list_interactions`` to see what\n",
+      "instance interactions are available after creation.\n",
+      "- staging_list_object_types: List all object types that can be staged in this session.\n",
+      "\n",
+      "Returns each type with its supported lifecycle operations: ``create``\n",
+      "(local build), ``import`` (from Evo), and ``publish`` modes back to Evo.\n",
+      "\n",
+      "Use ``staging_list_interactions`` with an ``object_type`` to see the\n",
+      "interactions available once an object of that type is staged.\n",
+      "- add_users_to_instance: Add one or more users to the selected instance.\n",
+      "If the user is external, an invitation will be sent.\n",
+      "\n",
+      "Only an instance admin or owner can add users to the instance. If a Forbidden error is returned from add_users_to_instance(),\n",
+      "inform the user of the tool that they do not have the required permissions to add users to the instance.\n",
+      "If a user is already in the instance, an error will be returned - give the error details to the user of the tool\n",
+      "and ask the user if they wish to update the role of this user. If role update is requested, use `update_user_role_in_instance` tool instead.\n",
+      "This will help in cases where the user is already in the instance but with a different role,\n",
+      "and we want to update the role of the user instead of adding the user again.\n",
+      "With one request, assign the same role to multiple users by accepting a list of user emails and a list of role IDs.\n",
+      "- staging_invoke_interaction: Invoke a named interaction on a staged object.\n",
+      "\n",
+      "Use ``staging_list_interactions`` first to discover available interactions\n",
+      "and their parameters for a given object type.\n",
+      "- staging_list: List active or filtered stages. Optionally filter by object_type, workspace_id, or status.\n",
+      "- get_object: Get object metadata by ID or path.\n",
+      "- get_users_in_instance: Get all users in the currently selected instance.\n",
+      "\n",
+      "This tool will allow an admin to see:\n",
+      "    * who has access to the instance,\n",
+      "    * who does not have access to the instance,\n",
+      "    * what roles a user has in the instance.\n",
+      "\n",
+      "The admin can take action to add or remove users from the instance based on this information.\n",
+      "\n",
+      "Use the `count` parameter to return only a sample of the users in the\n",
+      "instance.\n",
+      "\n",
+      "Returns:\n",
+      "    A list of users in the instance, their names, email addresses and roles.\n",
+      "- list_workspaces: List workspaces with optional filtering by name or deleted status.\n",
+      "- staging_import_object: Import a published object from Evo into the session.\n",
+      "\n",
+      "The object type is detected automatically from the Evo schema.\n",
+      "Use ``staging_list_object_types`` to see which types support import.\n",
+      "- staging_publish_object: Publish a staged object to Evo.\n",
+      "\n",
+      "The object type is detected automatically from the staged payload.\n",
+      "Use ``staging_list_object_types`` to check which publish modes an object type supports.\n",
+      "\n",
+      "- mode='create': Creates a new Evo object. Requires object_path.\n",
+      "- mode='new_version': Publishes as a new version of an existing object.\n",
+      "  Requires object_id.\n",
+      "\n",
+      "get_schema(['list_objects', 'get_object_versions']):\n",
+      "### list_objects\n",
+      "\n",
+      "List objects in a workspace with optional filtering.\n",
+      "\n",
+      "**Parameters**\n",
+      "- `workspace_id` (string, required)\n",
+      "- `schema_id` (string)\n",
+      "- `deleted` (boolean)\n",
+      "- `limit` (integer)\n",
+      "\n",
+      "**Returns**\n",
+      "- `result` (object[], required)\n",
+      "\n",
+      "Tools not found: get_object_versions\n"
+     ]
+    }
+   ],
+   "source": [
+    "async with Client(build_live_server(\"code-mode\")) as c:\n",
+    "    print(\"search('workspace objects and versions'):\")\n",
+    "    print((await c.call_tool(\"search\", {\"query\": \"workspace objects and versions\"})).data)\n",
+    "    print()\n",
+    "    print(\"get_schema(['list_objects', 'get_object_versions']):\")\n",
+    "    print((await c.call_tool(\"get_schema\", {\"tools\": [\"list_objects\", \"get_object_versions\"]})).data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acce869b",
+   "metadata": {},
+   "source": [
+    "### 6d. The workflow the model *would* write (presented, not executed)\n",
+    "Under `code-mode`, after discovering the real tools above, the model would author a script like the\n",
+    "one below and call `execute(code=...)`. Running it hits live Evo and needs credentials + a real\n",
+    "`workspace_id`, so here we only **display** it — no execution.\n",
+    "\n",
+    "> To actually run it, a reviewer *with* credentials and a selected instance would pass this string to\n",
+    "> the real server's `execute` tool for their own `workspace_id`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "e8d61b11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T21:09:30.035967Z",
+     "iopub.status.busy": "2026-07-08T21:09:30.035892Z",
+     "iopub.status.idle": "2026-07-08T21:09:30.037775Z",
+     "shell.execute_reply": "2026-07-08T21:09:30.037427Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "# Summarise a workspace without flooding context: count objects per schema,\n",
+      "# and report total points across all pointsets — all folded server-side.\n",
+      "wid = \"<your-workspace-id>\"\n",
+      "objs = (await call_tool(\"list_objects\", {\"workspace_id\": wid}))[\"result\"]\n",
+      "\n",
+      "by_schema = {}\n",
+      "total_points = 0\n",
+      "for o in objs:\n",
+      "    by_schema[o[\"schema\"]] = by_schema.get(o[\"schema\"], 0) + 1\n",
+      "    if o[\"schema\"] == \"pointset\":\n",
+      "        r = await call_tool(\"count_points\", {\"workspace_id\": wid, \"object_id\": o[\"id\"]})\n",
+      "        total_points += r[\"result\"]\n",
+      "\n",
+      "# Only this small summary returns to the model — not the raw object list.\n",
+      "return {\"object_count\": len(objs), \"by_schema\": by_schema, \"total_points\": total_points}\n",
+      "\n",
+      "# (Not executed here — discovery-only section. Pass to execute() on the live server to run.)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Presentation only — this cell prints the code, it does NOT execute it against Evo.\n",
+    "sample_workflow = \"\"\"\n",
+    "# Summarise a workspace without flooding context: count objects per schema,\n",
+    "# and report total points across all pointsets — all folded server-side.\n",
+    "wid = \"<your-workspace-id>\"\n",
+    "objs = (await call_tool(\"list_objects\", {\"workspace_id\": wid}))[\"result\"]\n",
+    "\n",
+    "by_schema = {}\n",
+    "total_points = 0\n",
+    "for o in objs:\n",
+    "    by_schema[o[\"schema\"]] = by_schema.get(o[\"schema\"], 0) + 1\n",
+    "    if o[\"schema\"] == \"pointset\":\n",
+    "        r = await call_tool(\"count_points\", {\"workspace_id\": wid, \"object_id\": o[\"id\"]})\n",
+    "        total_points += r[\"result\"]\n",
+    "\n",
+    "# Only this small summary returns to the model — not the raw object list.\n",
+    "return {\"object_count\": len(objs), \"by_schema\": by_schema, \"total_points\": total_points}\n",
+    "\"\"\"\n",
+    "print(sample_workflow)\n",
+    "print(\"# (Not executed here — discovery-only section. Pass to execute() on the live server to run.)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56511052",
+   "metadata": {},
+   "source": [
+    "## 7. Side-by-side summary\n",
+    "```\n",
+    "strategy       upfront tools  schema chars   ~tokens\n",
+    "----------------------------------------------------\n",
+    "none                      15          7257      1814\n",
+    "tool-search                2          1316       329\n",
+    "code-mode                  3          2527       631\n",
+    "\n",
+    "Takeaways:\n",
+    " - none:        deterministic, simplest; cost scales with catalog size.\n",
+    " - tool-search: constant upfront cost; still 1 round-trip + raw result per call.\n",
+    " - code-mode:   constant upfront cost; collapses multi-step workflows + hides intermediates.\n",
+    " ```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "evo-mcp (3.13.12)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/poc/tool_strategy.py
+++ b/src/poc/tool_strategy.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: 2026 Bentley Systems, Incorporated
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tool-exposure strategy factory for Evo MCP.
+
+A single place that decides *how* an LLM sees and reaches the tool catalog:
+
+  - ``none``        — the full catalog is listed upfront (today's behavior).
+  - ``tool-search`` — the catalog is hidden behind ``search_tools`` / ``call_tool``
+                      (FastMCP Tool Search transform).
+  - ``code-mode``   — the catalog is hidden behind ``search`` / ``get_schema`` /
+                      ``execute``; the LLM writes Python that chains tool calls in a
+                      sandbox (FastMCP Code Mode transform).
+
+The strategy is selected with the ``MCP_TOOL_STRATEGY`` environment variable and
+applied to an already-populated :class:`FastMCP` server with :func:`apply_strategy`.
+
+This module is intentionally free of Evo-specific imports so it can wrap both the
+real server (``src/mcp_tools.py``) and the PoC demo server.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from enum import Enum
+
+from fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+STRATEGY_ENV = "MCP_TOOL_STRATEGY"
+SEARCH_ENGINE_ENV = "MCP_SEARCH_ENGINE"
+
+
+class ToolStrategy(str, Enum):
+    """How the tool catalog is exposed to the LLM."""
+
+    NONE = "none"
+    TOOL_SEARCH = "tool-search"
+    CODE_MODE = "code-mode"
+
+
+class SearchEngine(str, Enum):
+    """Ranking engine used by the Tool Search strategy."""
+
+    BM25 = "bm25"
+    REGEX = "regex"
+
+
+def strategy_from_env() -> ToolStrategy:
+    """Read the desired strategy from ``MCP_TOOL_STRATEGY`` (default ``none``)."""
+    raw = os.getenv(STRATEGY_ENV, ToolStrategy.NONE.value).strip().lower()
+    try:
+        return ToolStrategy(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r; valid values are %s. Defaulting to 'none'.",
+            STRATEGY_ENV,
+            raw,
+            [s.value for s in ToolStrategy],
+        )
+        return ToolStrategy.NONE
+
+
+def search_engine_from_env() -> SearchEngine:
+    """Read the Tool Search engine from ``MCP_SEARCH_ENGINE`` (default ``bm25``)."""
+    raw = os.getenv(SEARCH_ENGINE_ENV, SearchEngine.BM25.value).strip().lower()
+    try:
+        return SearchEngine(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r; valid values are %s. Defaulting to 'bm25'.",
+            SEARCH_ENGINE_ENV,
+            raw,
+            [e.value for e in SearchEngine],
+        )
+        return SearchEngine.BM25
+
+
+def _build_tool_search_transform(
+    engine: SearchEngine,
+    *,
+    max_results: int,
+    always_visible: list[str] | None,
+):
+    """Construct a Tool Search transform for the requested engine."""
+    from fastmcp.server.transforms.search import (
+        BM25SearchTransform,
+        RegexSearchTransform,
+    )
+
+    cls = BM25SearchTransform if engine is SearchEngine.BM25 else RegexSearchTransform
+    return cls(max_results=max_results, always_visible=always_visible or None)
+
+
+def _build_code_mode_transform():
+    """Construct a Code Mode transform with the default staged discovery + sandbox.
+
+    Importing here keeps the ``fastmcp[code-mode]`` extra optional: the import only
+    happens when the code-mode strategy is actually selected.
+    """
+    from fastmcp.experimental.transforms.code_mode import CodeMode
+
+    return CodeMode()
+
+
+def apply_strategy(
+    mcp: FastMCP,
+    strategy: ToolStrategy | None = None,
+    *,
+    search_engine: SearchEngine | None = None,
+    max_results: int = 5,
+    always_visible: list[str] | None = None,
+) -> ToolStrategy:
+    """Apply a tool-exposure *strategy* to an already-populated *mcp* server.
+
+    Call this AFTER all tools have been registered, because the search index and
+    the code-mode catalog are built from the current tool set.
+
+    Args:
+        mcp: A FastMCP server that already has its tools registered.
+        strategy: The strategy to apply. Defaults to :func:`strategy_from_env`.
+        search_engine: Engine for the tool-search strategy. Defaults to
+            :func:`search_engine_from_env`.
+        max_results: Max tools returned per ``search_tools`` call (tool-search only).
+        always_visible: Tool names to keep pinned in ``list_tools`` regardless of
+            strategy (e.g. a ``help`` or ``select_instance`` tool).
+
+    Returns:
+        The :class:`ToolStrategy` that was applied.
+    """
+    strategy = strategy or strategy_from_env()
+
+    if strategy is ToolStrategy.NONE:
+        logger.info("Tool strategy: none (full catalog listed upfront).")
+        return strategy
+
+    if strategy is ToolStrategy.TOOL_SEARCH:
+        engine = search_engine or search_engine_from_env()
+        transform = _build_tool_search_transform(engine, max_results=max_results, always_visible=always_visible)
+        mcp.add_transform(transform)
+        logger.info("Tool strategy: tool-search (engine=%s).", engine.value)
+        return strategy
+
+    if strategy is ToolStrategy.CODE_MODE:
+        mcp.add_transform(_build_code_mode_transform())
+        logger.info("Tool strategy: code-mode (staged discovery + sandbox).")
+        return strategy
+
+    return ToolStrategy.NONE  # pragma: no cover - defensive

--- a/uv.lock
+++ b/uv.lock
@@ -268,12 +268,94 @@ wheels = [
 ]
 
 [[package]]
+name = "appnope"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
+]
+
+[[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/ba4e4ca8d149f8dcc0d952ac0967089e1d759c7e5fcf0865a317eb680fbb/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:6dca33a9859abf613e22733131fc9194091c1fa7cb3e131c143056b4856aa47e", size = 24549, upload-time = "2025-07-30T10:02:00.101Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/82/9b2386cc75ac0bd3210e12a44bfc7fd1632065ed8b80d573036eecb10442/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:21378b40e1b8d1655dd5310c84a40fc19a9aa5e6366e835ceb8576bf0fea716d", size = 25539, upload-time = "2025-07-30T10:02:00.929Z" },
+    { url = "https://files.pythonhosted.org/packages/31/db/740de99a37aa727623730c90d92c22c9e12585b3c98c54b7960f7810289f/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d588dec224e2a83edbdc785a5e6f3c6cd736f46bfd4b441bbb5aa1f5085e584", size = 28467, upload-time = "2025-07-30T10:02:02.08Z" },
+    { url = "https://files.pythonhosted.org/packages/71/7a/47c4509ea18d755f44e2b92b7178914f0c113946d11e16e626df8eaa2b0b/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5acb4e41090d53f17ca1110c3427f0a130f944b896fc8c83973219c97f57b690", size = 27355, upload-time = "2025-07-30T10:02:02.867Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/82/82745642d3c46e7cea25e1885b014b033f4693346ce46b7f47483cf5d448/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:da0c79c23a63723aa5d782250fbf51b768abca630285262fb5144ba5ae01e520", size = 29187, upload-time = "2025-07-30T10:02:03.674Z" },
+]
+
+[[package]]
+name = "arrow"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/33/032cdc44182491aa708d06a68b62434140d8c50820a087fac7af37703357/arrow-1.4.0.tar.gz", hash = "sha256:ed0cc050e98001b8779e84d461b0098c4ac597e88704a655582b21d116e526d7", size = 152931, upload-time = "2025-10-18T17:46:46.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl", hash = "sha256:749f0769958ebdc79c173ff0b0670d59051a535fa26e8eba02953dc19eb43205", size = 68797, upload-time = "2025-10-18T17:46:45.663Z" },
+]
+
+[[package]]
 name = "asttokens"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
+name = "async-lru"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/1f/989ecfef8e64109a489fff357450cb73fa73a865a92bd8c272170a6922c2/async_lru-2.3.0.tar.gz", hash = "sha256:89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6", size = 16332, upload-time = "2026-03-19T01:04:32.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/e2/c2e3abf398f80732e58b03be77bde9022550d221dd8781bf586bd4d97cc1/async_lru-2.3.0-py3-none-any.whl", hash = "sha256:eea27b01841909316f2cc739807acea1c623df2be8c5cfad7583286397bb8315", size = 8403, upload-time = "2026-03-19T01:04:30.883Z" },
 ]
 
 [[package]]
@@ -308,6 +390,15 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -332,6 +423,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
+name = "bleach"
+version = "6.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/3c/e12ac860709702bd5ebeb9b56a4fe334f1001246ee1b8f2b7ee28912df7d/bleach-6.4.0.tar.gz", hash = "sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452", size = 204857, upload-time = "2026-06-05T13:01:13.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl", hash = "sha256:4b6b6a54fff2e69a3dde9d21cc6301220bee3c3cb792187d11403fd795031081", size = 165109, upload-time = "2026-06-05T13:01:12.504Z" },
+]
+
+[package.optional-dependencies]
+css = [
+    { name = "tinycss2" },
 ]
 
 [[package]]
@@ -617,6 +738,15 @@ wheels = [
 ]
 
 [[package]]
+name = "comm"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -694,12 +824,50 @@ wheels = [
 ]
 
 [[package]]
+name = "debugpy"
+version = "1.8.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/aa/12037145b7a56eaa5b29b41872f7a21b538e807e13f32c4d3c46e59be084/debugpy-1.8.21.tar.gz", hash = "sha256:a3c53278e84c94e11bd87c53970ec391d1a67396c8b22609fcac576520e611a6", size = 1697577, upload-time = "2026-06-01T19:30:35.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/f3/6b1d4c71f4cbb5360009f928934a03b42906f28fc7b3f7f35f04e58acead/debugpy-1.8.21-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:8eeab7b5462f683452c57c0126aaa5ec4e974ddb705f39ba87dff8818c8e08f9", size = 2113873, upload-time = "2026-06-01T19:30:37.148Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f2/17c3bf91cebc173bfbf5734cd2669723d0a35c0cf9d2fd2124546efeae83/debugpy-1.8.21-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:0fddfdc130ac6d8bfc0415b0409822fa901c8f310e5c945ac5653a0352532344", size = 3004715, upload-time = "2026-06-01T19:30:38.888Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/22/1f8efd80c7b5909e760f9cfd0c9e8681d2d35d532f7c0a40760cd4da4a19/debugpy-1.8.21-cp310-cp310-win32.whl", hash = "sha256:72b5d676c4cbfac3bac5bb01c138a4656e843f93f03ce2a5f4e394ad49fbee73", size = 5303455, upload-time = "2026-06-01T19:30:40.52Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ce/54c79abd6cccef92fa7b43d97e3acafedf4d645557267ece05e948b5e4b8/debugpy-1.8.21-cp310-cp310-win_amd64.whl", hash = "sha256:a7fe47fd23da57b9e0bec3f4a8ee65a2dc55782455ed7f2141d75ab5d2eaeef5", size = 5331751, upload-time = "2026-06-01T19:30:42.146Z" },
+    { url = "https://files.pythonhosted.org/packages/89/fb/cbf306d6e07a313a91e7171a98669054502840931432c227cfd505ee367f/debugpy-1.8.21-cp311-cp311-macosx_15_0_universal2.whl", hash = "sha256:da456226c7b4c69e35dbe35dcee6623d912000a77816db7856a41af1c72a0264", size = 2203120, upload-time = "2026-06-01T19:30:43.964Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/57/aa739bd4ad2cbf96aeb1b20b56918ddd5ae4c28b68709bfcd327f02123ee/debugpy-1.8.21-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:f68b891688e61bdc08b8d364d919ff0051e0b94657b39dcd027bc3173edb7cdc", size = 3059958, upload-time = "2026-06-01T19:30:45.622Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/31/453d2c9a23d133fe2c8ec7ca1d816ded52a913487fe3ffef7c01b4b706af/debugpy-1.8.21-cp311-cp311-win32.whl", hash = "sha256:f843a8b08c2edeaf9b1582eed4f25441af21a297c22ff16bf76a662557aa9c9e", size = 5236515, upload-time = "2026-06-01T19:30:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/60/94/6660de2f2d7bf388f229335ba4637646eebabdbf38564cb439a95a9193c9/debugpy-1.8.21-cp311-cp311-win_amd64.whl", hash = "sha256:84c564d8cc701d41843b29a92814c1f1bef6798724ca9d675c284ad9f6a547d7", size = 5256138, upload-time = "2026-06-01T19:30:49.113Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/df/bf625547431a9cadc9f4cbfeda38866e2b17f6aed147b625377e87834449/debugpy-1.8.21-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:9f96713896f39c3dff0ee841f47320c3f2983d33c341e009361bb0ebc79adc4e", size = 2483609, upload-time = "2026-06-01T19:30:50.794Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/09/59324b903599031ff9faaec1758292409f6561a0ec2492fe4b703327705a/debugpy-1.8.21-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:c193d474f0a211191f2b4449d2d06157c689013035bd952f3b617e0ef422b176", size = 3968900, upload-time = "2026-06-01T19:30:52.341Z" },
+    { url = "https://files.pythonhosted.org/packages/14/cd/27f65b805d7fe005c44e1a36b9183ecdfbcdbf9d3e721a5115d461ecc7ee/debugpy-1.8.21-cp312-cp312-win32.whl", hash = "sha256:4743373c1cac7f9e74a1b9915bf1dbe0e900eca657ffb170ae07ac8363205ae9", size = 5336340, upload-time = "2026-06-01T19:30:54.047Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1d/c84e30c0c674184948b66f076ab271c01d940618a2824c23cd035a27bc20/debugpy-1.8.21-cp312-cp312-win_amd64.whl", hash = "sha256:bd7ba9dd3daa7c2f942c6ca8d4695a16bf9ac16b63615261c7982bc74f7ed20c", size = 5374751, upload-time = "2026-06-01T19:30:55.891Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6b/d817e1f8cc77aa055d37fba092e0febfdff40fe652d8d53d4cd7a86ad98d/debugpy-1.8.21-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:13678151fc401e2d68c9880b91e28714f797d40422994572b24560ef80910a88", size = 2477398, upload-time = "2026-06-01T19:30:57.644Z" },
+    { url = "https://files.pythonhosted.org/packages/48/57/412421516afc3055fa577516f00beec3d663f9b0ab330639547ae6c57720/debugpy-1.8.21-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:ecbd158386c31ffe71d46f72d44d56e66331ab9b16cad649156d514368f23ab2", size = 3962096, upload-time = "2026-06-01T19:30:59.235Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2c616337cf6ba7b07ebbc97f02c6c945a8e2f76b365e33ee809c32ee36d1/debugpy-1.8.21-cp313-cp313-win32.whl", hash = "sha256:2c2ae706dec41d99a9ca1f7ebc987a83e65578363be6f6b3ac9067504917fae1", size = 5336288, upload-time = "2026-06-01T19:31:00.79Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/99/9175103392f84c4b1bf7622888cdc68da07f0ff7d9e581266428f6776033/debugpy-1.8.21-cp313-cp313-win_amd64.whl", hash = "sha256:aa648733047443eb1d07682c4ef287d36a54507b643ffdf38b09a3ef002c72a0", size = 5376567, upload-time = "2026-06-01T19:31:02.56Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3d/f4bbb323a548bfab2af3d6b4ffd9bf22636e55956a1285d317a1de643aad/debugpy-1.8.21-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9bb2a685287a2ac9b181cde89edcec64845cb51de7faaa75badb9a698bc24782", size = 2477209, upload-time = "2026-06-01T19:31:04.157Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/2d/6e7ec524984a1702777868de49a4c53202bddac2a432a76a093469587750/debugpy-1.8.21-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:3d6922439bf33fd38a3e2c447869ebc7b97da5cd3d329ff1ef9bc06c4903437e", size = 3927115, upload-time = "2026-06-01T19:31:05.863Z" },
+    { url = "https://files.pythonhosted.org/packages/97/47/d1aa6d64005a98a9144647d99306b419396f9ad7bf1d73c119e17a81fb4d/debugpy-1.8.21-cp314-cp314-win32.whl", hash = "sha256:15d4963bd5ffa48f0da0947fd06757fa7621945048a14ad7705431566d3c0e7c", size = 5336724, upload-time = "2026-06-01T19:31:07.711Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/b905b90d163af11878c1af8abafa4a25206335e112e284e413454543a6da/debugpy-1.8.21-cp314-cp314-win_amd64.whl", hash = "sha256:fe0744a12353406de0ae8ccff0d0a4a666f00801a3db8fd04e7a5f761cd520e8", size = 5373803, upload-time = "2026-06-01T19:31:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl", hash = "sha256:b1e37d333663c8851516a47364ef473da127f9caebe4417e6df6f5825a7e9a92", size = 5352888, upload-time = "2026-06-01T19:31:25.186Z" },
+]
+
+[[package]]
 name = "decorator"
 version = "5.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5c/50/a39dd7ab407e93978dfa07d109b7d633e37958c89f30cbcec061b77b3ebc/decorator-5.3.0.tar.gz", hash = "sha256:95fda3122972c847cf0ff7e0ce2829bf25136f2526b627b3da85b60ca5f485c0", size = 58431, upload-time = "2026-05-17T06:59:57.258Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/6f/f8d0bba4dc2a69817d74f640d504650241ebf2f9f7263426f1b953b344d4/decorator-5.3.0-py3-none-any.whl", hash = "sha256:f8c2d71ede92f073144ddd7f3e9fbbc3bd0f2f29522c9d75ee648d66553834f4", size = 11104, upload-time = "2026-05-17T06:59:54.676Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
 ]
 
 [[package]]
@@ -821,7 +989,7 @@ dependencies = [
     { name = "evo-schemas" },
     { name = "evo-sdk-common" },
     { name = "evo-widgets" },
-    { name = "fastmcp" },
+    { name = "fastmcp", extra = ["code-mode"] },
     { name = "google-adk" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -840,6 +1008,10 @@ dev = [
     { name = "reuse" },
     { name = "ruff" },
 ]
+poc = [
+    { name = "ipykernel" },
+    { name = "jupyterlab" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -850,8 +1022,10 @@ requires-dist = [
     { name = "evo-schemas", specifier = ">=2025.9.2" },
     { name = "evo-sdk-common", specifier = ">=0.5.21" },
     { name = "evo-widgets", specifier = ">=0.2.0" },
-    { name = "fastmcp", specifier = ">=3.2.4" },
+    { name = "fastmcp", extras = ["code-mode"], specifier = ">=3.2.4" },
     { name = "google-adk", specifier = "==1.28.1" },
+    { name = "ipykernel", marker = "extra == 'poc'", specifier = ">=6" },
+    { name = "jupyterlab", marker = "extra == 'poc'", specifier = ">=4" },
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4" },
@@ -863,7 +1037,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.4" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "poc"]
 
 [[package]]
 name = "evo-objects"
@@ -974,6 +1148,15 @@ wheels = [
 ]
 
 [[package]]
+name = "fastjsonschema"
+version = "2.21.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/b5/23b216d9d985a956623b6bd12d4086b60f0059b27799f23016af04a74ea1/fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de", size = 374130, upload-time = "2025-08-14T18:49:36.666Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463", size = 24024, upload-time = "2025-08-14T18:49:34.776Z" },
+]
+
+[[package]]
 name = "fastmcp"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -983,6 +1166,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3b/a9/5c5a01b6abd5346bf60b97cfd29e4a86661940c27dd562bfcda07fd03519/fastmcp-3.3.1.tar.gz", hash = "sha256:979362ea557de42a5f40342563c7e4b236bcc8e7cd192715f50030695d1a71cd", size = 28681699, upload-time = "2026-05-15T15:50:39.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/11/6b1bdada6ccfe647d615ae63f9106f8136aec17971e9361546af01c7d38e/fastmcp-3.3.1-py3-none-any.whl", hash = "sha256:862440c5c4d281363a5995eee59d77f0f7cac1f18869038729cecf03b02fc522", size = 7903, upload-time = "2026-05-15T15:50:36.424Z" },
+]
+
+[package.optional-dependencies]
+code-mode = [
+    { name = "fastmcp-slim", extra = ["code-mode"] },
 ]
 
 [[package]]
@@ -1010,6 +1198,9 @@ client = [
     { name = "mcp" },
     { name = "opentelemetry-api" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+]
+code-mode = [
+    { name = "pydantic-monty" },
 ]
 server = [
     { name = "authlib" },
@@ -1040,6 +1231,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "fqdn"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f", size = 6015, upload-time = "2021-03-11T07:16:29.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014", size = 9121, upload-time = "2021-03-11T07:16:28.351Z" },
 ]
 
 [[package]]
@@ -1994,6 +2194,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ipykernel"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "comm" },
+    { name = "debugpy" },
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "matplotlib-inline" },
+    { name = "nest-asyncio2" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/c4/e4a38f579de4225a561305666f7541cdabb30075def2aa1ac17bd73c1fb5/ipykernel-7.3.0.tar.gz", hash = "sha256:9acaaaf97d16355166e4085afe9d225bfbdf2b7ef520f9df3be8f2b248275e09", size = 184899, upload-time = "2026-06-10T08:41:25.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/02/77b271f5dc58bfbc0b577c877b2365d1ffea2afe66a80c13f2312820348c/ipykernel-7.3.0-py3-none-any.whl", hash = "sha256:897eb64da762549ef610698fca5e9675195ec6ac8ec7f19d81ce1ca20c876057", size = 120583, upload-time = "2026-06-10T08:41:23.648Z" },
+]
+
+[[package]]
 name = "ipython"
 version = "8.39.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2062,6 +2287,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "isoduration"
+version = "20.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arrow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", hash = "sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042", size = 11321, upload-time = "2020-11-01T10:59:58.02Z" },
 ]
 
 [[package]]
@@ -2155,6 +2392,15 @@ wheels = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/7d/05c46a96a78147ae3bf99c2f4169ce144a70220b8d6fcd56f6ec368b8ce9/json5-0.15.0.tar.gz", hash = "sha256:7424d1f1eb1d56da6e3d70643f53619862b4ce81440bdb8ecfd6f875e5ba4a71", size = 53278, upload-time = "2026-06-19T20:08:27.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/be/59527c99478aade6bb33a68d72e6e18dd4e6ff6eacfc7d01bdb15bc76912/json5-0.15.0-py3-none-any.whl", hash = "sha256:56636a30c0e8a4665fe2179c0212f32eae3796dea89ea6f649b9436ecdb39618", size = 36570, upload-time = "2026-06-19T20:08:26.748Z" },
+]
+
+[[package]]
 name = "jsonpointer"
 version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2187,6 +2433,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
 ]
 
+[package.optional-dependencies]
+format-nongpl = [
+    { name = "fqdn" },
+    { name = "idna" },
+    { name = "isoduration" },
+    { name = "jsonpointer" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "rfc3987-syntax" },
+    { name = "uri-template" },
+    { name = "webcolors" },
+]
+
 [[package]]
 name = "jsonschema-path"
 version = "0.4.6"
@@ -2214,6 +2473,176 @@ wheels = [
 ]
 
 [[package]]
+name = "jupyter-builder"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/45/d0df8b43c10a61529c0f4a8af5e19ebe108f0c3af8f57e0fc358969907af/jupyter_builder-1.0.2.tar.gz", hash = "sha256:6155d78a5325010532a6419ffcba89eac643fd1aa56ea83115e661924d6f6aab", size = 968638, upload-time = "2026-06-12T02:33:25.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/b6/c418e0b3256f67c04933566b80bfce947350682db92c4b786a8653db32d6/jupyter_builder-1.0.2-py3-none-any.whl", hash = "sha256:b024f65d36e1d530542db597b00dd513261aa59842e0d0fbbb1015a9f1935e9c", size = 910789, upload-time = "2026-06-12T02:33:23.317Z" },
+]
+
+[[package]]
+name = "jupyter-client"
+version = "8.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "python-dateutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/dc/5512503b088997c2250b8bf18258fba9d9ce5ead641183700960d3c9d342/jupyter_client-8.9.1.tar.gz", hash = "sha256:a58f730dd9e728ba16ba1d62ebccf7ffe1ebbdbce4e95cfae941b7321ae1f4fa", size = 359256, upload-time = "2026-06-09T13:15:01.033Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/6f/56d39bf385c5c27988aebaf0c18a2a17e960575740100973511018bd904e/jupyter_client-8.9.1-py3-none-any.whl", hash = "sha256:0b7a295bc46e8751e9adae84781f726c851c1d911bd793edc4a3bde942e3da81", size = 109828, upload-time = "2026-06-09T13:14:58.835Z" },
+]
+
+[[package]]
+name = "jupyter-core"
+version = "5.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
+]
+
+[[package]]
+name = "jupyter-events"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema", extra = ["format-nongpl"] },
+    { name = "packaging" },
+    { name = "python-json-logger" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/f8/475c4241b2b75af0deaae453ed003c6c851766dbc44d332d8baf245dc931/jupyter_events-0.12.1.tar.gz", hash = "sha256:faff25f77218335752f35f23c5fe6e4a392a7bd99a5939ccb9b8fbf594636cf3", size = 62854, upload-time = "2026-04-20T23:17:50.66Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/6c/6fcde0c8f616ed360ffd3587f7db9e225a7e62b583a04494d2f069cf64ea/jupyter_events-0.12.1-py3-none-any.whl", hash = "sha256:c366585253f537a627da52fa7ca7410c5b5301fe893f511e7b077c2d93ec8bcf", size = 19512, upload-time = "2026-04-20T23:17:48.927Z" },
+]
+
+[[package]]
+name = "jupyter-lsp"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-server" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/ff/1e4a61f5170a9a1d978f3ac3872449de6c01fc71eaf89657824c878b1549/jupyter_lsp-2.3.1.tar.gz", hash = "sha256:fdf8a4aa7d85813976d6e29e95e6a2c8f752701f926f2715305249a3829805a6", size = 55677, upload-time = "2026-04-02T08:10:06.749Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/e8/9d61dcbd1dce8ef418f06befd4ac084b4720429c26b0b1222bc218685eff/jupyter_lsp-2.3.1-py3-none-any.whl", hash = "sha256:71b954d834e85ff3096400554f2eefaf7fe37053036f9a782b0f7c5e42dadb81", size = 77513, upload-time = "2026-04-02T08:10:01.753Z" },
+]
+
+[[package]]
+name = "jupyter-server"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "argon2-cffi" },
+    { name = "jinja2" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "jupyter-events" },
+    { name = "jupyter-server-terminals" },
+    { name = "nbconvert" },
+    { name = "nbformat" },
+    { name = "overrides", marker = "python_full_version < '3.12'" },
+    { name = "packaging" },
+    { name = "prometheus-client" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pyzmq" },
+    { name = "send2trash" },
+    { name = "terminado" },
+    { name = "tornado" },
+    { name = "traitlets" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/dc/db3a582633170186f8c8b31298d7eb26ad0eb031a1f53476c258b64eed05/jupyter_server-2.20.0.tar.gz", hash = "sha256:b5778ba337d8015a3dc2b80803ecdd5ac18d3797fddf61a50ea5fb472b4ebe14", size = 756523, upload-time = "2026-06-17T12:09:09.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/71/8c002223e873a870f5c41dc69b0a7c922301123e4a31d5d01ecb700aef77/jupyter_server-2.20.0-py3-none-any.whl", hash = "sha256:c3b67c93c471e947c18b5026f04f21614218adb706df8f48227d3ee8e0a7cdcc", size = 393143, upload-time = "2026-06-17T12:09:07.234Z" },
+]
+
+[[package]]
+name = "jupyter-server-terminals"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "terminado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/2d/6674563f71c6320841fc300911a55143925112a72a883e2ca71fba4c618d/jupyter_server_terminals-0.5.4-py3-none-any.whl", hash = "sha256:55be353fc74a80bc7f3b20e6be50a55a61cd525626f578dcb66a5708e2007d14", size = 13704, upload-time = "2026-01-14T16:53:18.738Z" },
+]
+
+[[package]]
+name = "jupyterlab"
+version = "4.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-lru" },
+    { name = "httpx" },
+    { name = "ipykernel" },
+    { name = "jinja2" },
+    { name = "jupyter-builder" },
+    { name = "jupyter-core" },
+    { name = "jupyter-lsp" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab-server" },
+    { name = "notebook-shim" },
+    { name = "packaging" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/2a/d6af53bfd45a43a5bfe7e40ba47ee7a8921a807daf4bb708e3a295bbb54d/jupyterlab-4.6.1.tar.gz", hash = "sha256:75315982ed28427edaa62bb85eadb5105e4043a757643c910efd787fe6ed0837", size = 28179125, upload-time = "2026-06-29T12:48:45.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/81/90ac6cc31d248e83a0d1eab343a5e6e68bc783d3f74fbe61640f42a61da4/jupyterlab-4.6.1-py3-none-any.whl", hash = "sha256:85a58546c831f3dce6cf919468c26874c9065e99c42279fb4abb8e1b552a98bb", size = 17164660, upload-time = "2026-06-29T12:48:41.21Z" },
+]
+
+[[package]]
+name = "jupyterlab-pygments"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/51/9187be60d989df97f5f0aba133fa54e7300f17616e065d1ada7d7646b6d6/jupyterlab_pygments-0.3.0.tar.gz", hash = "sha256:721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d", size = 512900, upload-time = "2023-11-23T09:26:37.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl", hash = "sha256:841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780", size = 15884, upload-time = "2023-11-23T09:26:34.325Z" },
+]
+
+[[package]]
+name = "jupyterlab-server"
+version = "2.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "jinja2" },
+    { name = "json5" },
+    { name = "jsonschema" },
+    { name = "jupyter-server" },
+    { name = "packaging" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", hash = "sha256:35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c", size = 76996, upload-time = "2025-10-22T13:59:18.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/07/a000fe835f76b7e1143242ab1122e6362ef1c03f23f83a045c38859c2ae0/jupyterlab_server-2.28.0-py3-none-any.whl", hash = "sha256:e4355b148fdcf34d312bbbc80f22467d6d20460e8b8736bf235577dd18506968", size = 59830, upload-time = "2025-10-22T13:59:16.767Z" },
+]
+
+[[package]]
 name = "keyring"
 version = "25.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2229,6 +2658,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
+]
+
+[[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
 ]
 
 [[package]]
@@ -2396,6 +2834,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mistune"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/5f/007786743f962224423753b78f7d7acb0f2ade46d1604f2e0fa2bedf9020/mistune-3.3.2.tar.gz", hash = "sha256:e12ee4f1e74336e91aa1141e35f913b337c40bdf7c0cc49f21fb853a27e8b62f", size = 111284, upload-time = "2026-06-23T00:29:28.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/43/894c2cbbcbdf53b57d1257a249811abe2ee9ab7ef76af301b40f1c054533/mistune-3.3.2-py3-none-any.whl", hash = "sha256:a678a56387d487db7368ede4647cb2ba1deff22ce61f92343e4ebe0ddfce4f2d", size = 61554, upload-time = "2026-06-23T00:29:27.088Z" },
 ]
 
 [[package]]
@@ -2660,12 +3110,88 @@ wheels = [
 ]
 
 [[package]]
+name = "nbclient"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "nbformat" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/a5/b3bae4b590c0cbcada2c63a34f7580024e834a8ba213e949a2f906705787/nbclient-0.11.0.tar.gz", hash = "sha256:04a134a5b087f2c5887f228aca155db50169b8cd9334dee6942c8e927e56081a", size = 62535, upload-time = "2026-06-05T07:52:41.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/c9/94d73e5a01c5b926c3fa2496e97d7a8dc28ed5a77c0b2ed712f1a62e6694/nbclient-0.11.0-py3-none-any.whl", hash = "sha256:ef7fa0d59d6e1d41103933d8a445a18d5de860ca6b613b87b8574accdb3c2895", size = 25288, upload-time = "2026-06-05T07:52:40.115Z" },
+]
+
+[[package]]
+name = "nbconvert"
+version = "7.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "bleach", extra = ["css"] },
+    { name = "defusedxml" },
+    { name = "jinja2" },
+    { name = "jupyter-core" },
+    { name = "jupyterlab-pygments" },
+    { name = "markupsafe" },
+    { name = "mistune" },
+    { name = "nbclient" },
+    { name = "nbformat" },
+    { name = "packaging" },
+    { name = "pandocfilters" },
+    { name = "pygments" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/b1/708e53fe2e429c103c6e6e159106bcf0357ac41aa4c28772bd8402339051/nbconvert-7.17.1.tar.gz", hash = "sha256:34d0d0a7e73ce3cbab6c5aae8f4f468797280b01fd8bd2ca746da8569eddd7d2", size = 865311, upload-time = "2026-04-08T00:44:14.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/f8/bb0a9d5f46819c821dc1f004aa2cc29b1d91453297dbf5ff20470f00f193/nbconvert-7.17.1-py3-none-any.whl", hash = "sha256:aa85c087b435e7bf1ffd03319f658e285f2b89eccab33bc1ba7025495ab3e7c8", size = 261927, upload-time = "2026-04-08T00:44:12.845Z" },
+]
+
+[[package]]
+name = "nbformat"
+version = "5.10.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastjsonschema" },
+    { name = "jsonschema" },
+    { name = "jupyter-core" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2024-04-04T11:20:37.371Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl", hash = "sha256:3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b", size = 78454, upload-time = "2024-04-04T11:20:34.895Z" },
+]
+
+[[package]]
+name = "nest-asyncio2"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/73/731debf26e27e0a0323d7bda270dc2f634b398e38f040a09da1f4351d0aa/nest_asyncio2-1.7.2.tar.gz", hash = "sha256:1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8", size = 14743, upload-time = "2026-02-13T00:34:04.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl", hash = "sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01", size = 7843, upload-time = "2026-02-13T00:34:02.691Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "notebook-shim"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-server" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/d2/92fa3243712b9a3e8bafaf60aac366da1cada3639ca767ff4b5b3654ec28/notebook_shim-0.2.4.tar.gz", hash = "sha256:b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb", size = 13167, upload-time = "2024-02-14T23:35:18.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl", hash = "sha256:411a5be4e9dc882a074ccbcae671eda64cceb068767e9a3419096986560e1cef", size = 13307, upload-time = "2024-02-14T23:35:16.286Z" },
 ]
 
 [[package]]
@@ -2978,6 +3504,15 @@ wheels = [
 ]
 
 [[package]]
+name = "overrides"
+version = "7.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/86/b585f53236dec60aba864e050778b25045f857e17f6e5ea0ae95fe80edd2/overrides-7.7.0.tar.gz", hash = "sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a", size = 22812, upload-time = "2024-01-27T21:01:33.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl", hash = "sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49", size = 17832, upload-time = "2024-01-27T21:01:31.393Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3122,6 +3657,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pandocfilters"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/6f/3dd4940bbe001c06a65f88e36bad298bc7a0de5036115639926b0c5c0458/pandocfilters-1.5.1.tar.gz", hash = "sha256:002b4a555ee4ebc03f8b66307e287fa492e4a77b4ea14d3f934328297bb4939e", size = 8454, upload-time = "2024-01-18T20:08:13.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl", hash = "sha256:93be382804a9cdb0a7267585f157e5d1731bbe5545a85b268d6f5fe6232de2bc", size = 8663, upload-time = "2024-01-18T20:08:11.28Z" },
+]
+
+[[package]]
 name = "parso"
 version = "0.8.7"
 source = { registry = "https://pypi.org/simple" }
@@ -3183,6 +3727,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]
@@ -3669,6 +4222,77 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-monty"
+version = "0.0.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/d2/ddf8381f782e00721feed7000ce1393425dfb82aa8fae95b2cdc50ed4264/pydantic_monty-0.0.16.tar.gz", hash = "sha256:0c4310a3daa8edd3ea3622aed3f72f16042f0909f9b8e6880719feff23e8b10f", size = 1004038, upload-time = "2026-04-19T17:45:20.717Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/02/0ca37ac25a3985134f78d97a4fe16908a0ea901cde526e8c0c1bb29d8f28/pydantic_monty-0.0.16-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:f1635efc128330d2b630d24d5bcb5582beb0e54ad20e186f32d4e694669bad67", size = 7335290, upload-time = "2026-04-19T17:45:49.837Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/48/b0304500b3db2271607c5ff7e4e5217029870d1f20c873d80a3a774ff28f/pydantic_monty-0.0.16-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1899360dd3eb64d061f1da48f15e8470d0be7c72e6329eefc46da151cdfd6b12", size = 7319338, upload-time = "2026-04-19T17:45:22.43Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/53/0a628359e2a27ba6c1e3f3f76e53ddcd52d6f84f6932a4c7281d66fc3b66/pydantic_monty-0.0.16-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:79f32d75aef055ff96cfabaa0126b24a44075d9fe2e9b101dcc12359db63460f", size = 7846662, upload-time = "2026-04-19T17:44:33.693Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f6/0cbbe78708e989da16efd2dfe976a49d7014e231620927dfb9302db7ad53/pydantic_monty-0.0.16-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fb1fcb935beb3385cbd2ffb4729634ce8bac2159a829b3a2651dfbef6e52f8f", size = 7135383, upload-time = "2026-04-19T17:45:55.516Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9a/46975f06c5aa6ff8c85f76a4291108959e0f2b7d3b48bd434a3e47ce3ee6/pydantic_monty-0.0.16-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:aef82f3d7c612db9451d5d5b75306a8a33d97a4fc20ad154e2883993faf19180", size = 7424720, upload-time = "2026-04-19T17:45:51.771Z" },
+    { url = "https://files.pythonhosted.org/packages/82/ce/ec96099b43be8234575dde1fef9936b9f3450b3cbed7918aef9c3e9dbb54/pydantic_monty-0.0.16-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e5f9d9c13ac3d2eb3b2f5aaf1e65da0806628159701d90c6d3b59d2a08685629", size = 7951186, upload-time = "2026-04-19T17:45:08.38Z" },
+    { url = "https://files.pythonhosted.org/packages/41/d1/ad7754b28518874ff1ec021a83299d6214ba6a678532227619893b32a2f7/pydantic_monty-0.0.16-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d2ac23d8a7148a00a63e8266d3ffd7799cfabae53d37da72238e4ae66fae567", size = 8177319, upload-time = "2026-04-19T17:44:45.016Z" },
+    { url = "https://files.pythonhosted.org/packages/05/3b/7831e5034f0bb92b084cb38e16885c9a530afc117d3726690e8a596bb7ed/pydantic_monty-0.0.16-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6bbe77115afe96430c3f461fd06ca96f1295fda89e12663533c0c09cf2fc7c", size = 7751106, upload-time = "2026-04-19T17:46:00.725Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/17/0333bd76f7fd028f89c900084ab71e9439fc62637e6d8a8b5665b198a702/pydantic_monty-0.0.16-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:624a752cea28bcc6e46e70c049ee5b94d1bdc8886cece7b44f44e0bd3f084cda", size = 7308610, upload-time = "2026-04-19T17:44:48.4Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/48/f9c42f23ef7fc26b9950fc47929f167bd8c4aba193e03449b29ffcce3f62/pydantic_monty-0.0.16-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b1a0e24cc45c4aebf4264e88a32e68361ecc40e549ea0882b74adc8548d382ac", size = 7754541, upload-time = "2026-04-19T17:46:12.731Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/3f/2fccd3bdeab6ecca23146086138ea38f152a9c9c92d95518a9b6ef51841b/pydantic_monty-0.0.16-cp310-cp310-win32.whl", hash = "sha256:2416b7336d52431fb8375b62ed53a74a1c23141db96c5e342e5aaa2ca30be07a", size = 7215409, upload-time = "2026-04-19T17:44:41.358Z" },
+    { url = "https://files.pythonhosted.org/packages/94/d5/c33d41999746d9dc6678ed7af2e02138b1a8aa82693da9a0836f3c9c12aa/pydantic_monty-0.0.16-cp310-cp310-win_amd64.whl", hash = "sha256:827cad086668dd2da287da06e646bb952dbe9353b758e2dcc122207b531c5b8c", size = 8065895, upload-time = "2026-04-19T17:44:56.903Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0a/f869d16fb55f6c6ded6659009c2219d21a19925b441499716331760a5071/pydantic_monty-0.0.16-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:1eb136807127e9e7609b585ce4f13feedc1e4d670aa902a666ed6f6c1633d080", size = 7335058, upload-time = "2026-04-19T17:45:41.946Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fb/4a36fc1f9ebb447169da3c7bc1533836ca6b3e013e6dfdce96b6ff856f39/pydantic_monty-0.0.16-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bafb73a42bb75cc696c08c7e9866ab1344c82b7f94e2842b1211d6479d47d11", size = 7318194, upload-time = "2026-04-19T17:45:48.119Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/00/7a495ee3577eb918dbf8065293c272e7f884ac62d0ed4f39ca5fb5084c53/pydantic_monty-0.0.16-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:00090c735663c40698b887c2c92fdf181907c4eb1e0add4c95f03c23e6423174", size = 7846605, upload-time = "2026-04-19T17:45:26.314Z" },
+    { url = "https://files.pythonhosted.org/packages/48/2d/fe2a85203b3b75c9b69e3262df876fa5566d60383967c75c8fc2acf06dfe/pydantic_monty-0.0.16-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9267528c2b9ab3ac8ca81d9ee979e415523e3519e69095f2257f912333f30da8", size = 7135374, upload-time = "2026-04-19T17:45:59.132Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c5/6aa4c9eb01e11044c2d422bc3d454c9f127e58c6b3e45364d14689ada8e6/pydantic_monty-0.0.16-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7679143b6fbfc9641de3f34ac9766171fe6e9951af70115efffa3de31ff0e104", size = 7423454, upload-time = "2026-04-19T17:45:44.147Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/17/17383268d79f1cb7572325e0a30ccf3864fe5d106026b190b2f24382eb23/pydantic_monty-0.0.16-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e3329fd392375b069c169d901b49153df3a7655174b25f0aa69a3e5dc270b452", size = 7950704, upload-time = "2026-04-19T17:45:29.46Z" },
+    { url = "https://files.pythonhosted.org/packages/16/83/aa866d248ceaf4e6032eb262845727b9a70acbfd34f7f3301cd7c070ec4e/pydantic_monty-0.0.16-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e659e57da79096993549b2fe687b722c766f3d27cdd56591df9102b18ff0e45", size = 8177053, upload-time = "2026-04-19T17:45:31.234Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/7d/d29f6782ce826aeb8e6f4e75414707fb974fc270fa10199348879ab48583/pydantic_monty-0.0.16-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e791a44fdd4ec14af38bedff70e363eae7323877ec04c2920874cac1a95d3206", size = 7750080, upload-time = "2026-04-19T17:44:39.638Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d8/cfa10e31d60774c44ba0fdb40c784692f6c1bd0086e1723a0c53fe79c094/pydantic_monty-0.0.16-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:25d3484cf0c7a1f77698026fa532ee5bcff4b4560d76f280ef30224a15c746e2", size = 7308307, upload-time = "2026-04-19T17:45:00.53Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/24/b46e725d9c6ecae1a8fe3840e52f8da73203250f2454d831457020062be0/pydantic_monty-0.0.16-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:599c85757c9589682bc22f0cc9fde65461a099b5d5753d0a293f5cf33a09f733", size = 7754639, upload-time = "2026-04-19T17:45:13.356Z" },
+    { url = "https://files.pythonhosted.org/packages/68/0f/212d70e509fc57852eb668c845a0542f9d665523d19db6eaa15247aafd28/pydantic_monty-0.0.16-cp311-cp311-win32.whl", hash = "sha256:6ac9f9bb6b4c68eef26721216822583527e63098a37d443a77443e03706b66e1", size = 7214945, upload-time = "2026-04-19T17:46:04.319Z" },
+    { url = "https://files.pythonhosted.org/packages/51/70/f4c68863402f6a2f1aa6b73dba886b0c1e6eb5a4f529d1ed187b9fe92717/pydantic_monty-0.0.16-cp311-cp311-win_amd64.whl", hash = "sha256:a67b47a6119f4116b58481b357fb1c64d34acaa83220d989b349be1ed5c9a2ed", size = 8065603, upload-time = "2026-04-19T17:45:24.39Z" },
+    { url = "https://files.pythonhosted.org/packages/18/14/001815665ad793d334d926cd1a3d0a86ceab9ddb042d63da2dfce4f153b2/pydantic_monty-0.0.16-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f62efa2ebc1305826b646b60e1857a90b0ea8c370788a02b9d40d2ab5d505777", size = 7333666, upload-time = "2026-04-19T17:45:27.915Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/87/22423a512b649ea1ff02d37c72b247b137ef91688a4bda88b5978584d099/pydantic_monty-0.0.16-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4f963ea23bfb352da29dd1976821e1e47162e0e2b98065f092534dde85e41ccb", size = 7293613, upload-time = "2026-04-19T17:45:33.312Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/1d/fd31f7bbfbc004970209d4895a176d332f533b0337b75aa774d527a4fd09/pydantic_monty-0.0.16-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:93087d3ec044c5e929f10823fb563e809dbc7c623eb619362872403da7c406a6", size = 7847877, upload-time = "2026-04-19T17:46:02.478Z" },
+    { url = "https://files.pythonhosted.org/packages/91/a7/85b22d367787816ce3637f514df07eef06ec081c566edd6ce59e7a8ea319/pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb6cd319731e404bcc190d7867cf0ea1f5bf7124114893e277693f9b8b987201", size = 7134554, upload-time = "2026-04-19T17:44:43.392Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/5e/998a7aeebf3e12640f5300e8e42cc97dcbb4aeb94a4df6846f1704d73d9d/pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49e58d4e00d2721560f40ae92998b5b3670166e56db678f7c16853b916d888da", size = 7431773, upload-time = "2026-04-19T17:45:04.834Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c5/5554c3df0e20be6bb0bf3a59ce96e47238a630156a9ab5f568eeb6370265/pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:320d4bc67e58a17a526a2361737de874cc8824c610701551e75b456b7421feb8", size = 7952070, upload-time = "2026-04-19T17:44:51.742Z" },
+    { url = "https://files.pythonhosted.org/packages/28/fa/173e3d8738de03c0ad53aa8f6180d56a10ff62d059b90a47e915fc4db5ce/pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7a5eda5ecc4841bce0a9a9e1e059b71646a7bd5c990bc106edf717d2ec13d6cd", size = 8178124, upload-time = "2026-04-19T17:45:06.61Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/8c/c879f7d925c09e89e371a00597f6391cb4a547ce63b207897e7ef82e48a1/pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa7834fdee5db13f75bfe74ab91ef4d056be643ad841b9cec5338d097c1513ed", size = 7718778, upload-time = "2026-04-19T17:45:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/34/e3/69741eecc269c12e94dc9c6fc7513e3200aafaf602ca794ea11dadb0d9ee/pydantic_monty-0.0.16-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:5df4c31ac9d5b91b39eb9cdf81e4fdf1ccfe372fea1f4133cfc02e5654c62a5d", size = 7308908, upload-time = "2026-04-19T17:44:46.98Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f5/a5f010527c59cb8f8c7fe616c17f9016b5fe9ae6e1d077ad2213cd344349/pydantic_monty-0.0.16-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:6f13db1f0c1c970ad6289262273273f9d2e241e141539ad874e06ff0c736d86d", size = 7759289, upload-time = "2026-04-19T17:46:09.222Z" },
+    { url = "https://files.pythonhosted.org/packages/05/4d/ea909241588f38dee4e039c7b40896070f4ea49a71388ff3bf312cbed720/pydantic_monty-0.0.16-cp312-cp312-win32.whl", hash = "sha256:8585dd6a186a3d17d25237ea6f8ea4a8af3717c9503c08a3a582f5e5162e36a6", size = 7213401, upload-time = "2026-04-19T17:46:10.803Z" },
+    { url = "https://files.pythonhosted.org/packages/08/bd/a8cbee968d8df9cae0906de331affee8af33b68772f86c9500f498c74268/pydantic_monty-0.0.16-cp312-cp312-win_amd64.whl", hash = "sha256:326cddda37f0a684a5d8ca54113bd17657bf48399a0e022cdb8ae05581976bce", size = 8035415, upload-time = "2026-04-19T17:44:37.494Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/58/6efd919433d5fb80503a0d6e971ed1b28295a6fe4cba7a4706e9e484fe1b/pydantic_monty-0.0.16-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9615d19bcccd7f4ad95364368cfd74d5451f1eeeb7f0363ad292c56f75bbdac5", size = 7334030, upload-time = "2026-04-19T17:44:55.331Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/cd/d53c86d58983e7203c2ab9ac21defdff4e5b4e2a318a0ae435f825e381bf/pydantic_monty-0.0.16-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b9da2475d37d7614691d94b21035ad00161373592df9de2282c2929c00f2504e", size = 7293738, upload-time = "2026-04-19T17:45:11.487Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/64/b085a0b192c8aecec4ad225e6f1895a963ac584b3a2f8970201e70ff5347/pydantic_monty-0.0.16-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:07372b15eab8996ec6720a8ee4879f7b5fd53dd0589d818550d5244eacd68a96", size = 7847921, upload-time = "2026-04-19T17:44:58.659Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/9a/a169c6f3da169fdb49b7c679b7c9b04b2dc3c9ecff01cc470753a35634ca/pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a694ea0501f2ad115ec1b169d7665b554eb9448779fce11727472a4e8378d2c3", size = 7132619, upload-time = "2026-04-19T17:45:09.797Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d9/d04fe911ee70a07e9e30ebbd0a8665acc39c4fd1ba0fa4ca6fe022c113f7/pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f00c529865554b5edaefc796c4f52ed3686f91cb9cae2b164428353c2f2a773b", size = 7430974, upload-time = "2026-04-19T17:46:14.641Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/cd/3110b6ab4e8b237ce1ca47799d8ee0df409475011502c9ca21392466ca54/pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:95be0c370eeea1c185d96ff8d459e510fbce1508115bbed489f8d7b9a79e7505", size = 7951214, upload-time = "2026-04-19T17:45:36.475Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1b/a42f7ae39f99a36d07e03625615fb35685dfa78721c1ff9429e0620cd202/pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f6edd9338861544e9983a3d8412f27257cb246428b0a6dab945848af0790b294", size = 8177227, upload-time = "2026-04-19T17:44:31.815Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/8b/364cf60bba989a8a50d9127a8f3818437590c435ade07f4e81ddc9bc77a0/pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:011ab47525340b2802e2aa32ccac92fafc4fb516a48dd07ff563f2cd40203e37", size = 7717367, upload-time = "2026-04-19T17:45:40.103Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f3/6726e51d8a86aadcc638d26c33643e77d7f1f971475046d55bfc5af3f7fb/pydantic_monty-0.0.16-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:e5d25973f2884e0b845d2f028e1f972811c2a98708eb425bf5809747360939ad", size = 7308198, upload-time = "2026-04-19T17:45:02.364Z" },
+    { url = "https://files.pythonhosted.org/packages/69/a1/9fd2cdfc5720b34c822a0b34ad6c555e8d32c2fd6e35b52cdf3eeb2e5820/pydantic_monty-0.0.16-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:944a0ab7e81e4523ff9120f45b0ca22f377ad291d2257d251db02eb25727c5ac", size = 7757710, upload-time = "2026-04-19T17:46:05.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/52/8f742f63c10f7bf9696e428ba16970fa76ba8bb4d5cf9d3c19f7973d3d51/pydantic_monty-0.0.16-cp313-cp313-win32.whl", hash = "sha256:e6d4023ee3f0530edf57097ebc004f73d67636b39d2ebb21fca0eaed7bab9977", size = 7213500, upload-time = "2026-04-19T17:46:16.403Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5b/e58bbae39114ffcfefcd9afd87d215f65af2689356bb3100cfe1c85684d4/pydantic_monty-0.0.16-cp313-cp313-win_amd64.whl", hash = "sha256:c7c27b717ccba5a4cdd7321bc3a33fc97aede032784c41a1ce7d5906be04cf44", size = 8035107, upload-time = "2026-04-19T17:46:07.638Z" },
+    { url = "https://files.pythonhosted.org/packages/af/16/43c0c9220590b620fb1283221bb1565d64721666a863a0d1b11d5f617f51/pydantic_monty-0.0.16-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d42f100eda125bded8ba38f17c9998cca2ab645c4a795aa1be4bf754075899c5", size = 7333854, upload-time = "2026-04-19T17:45:53.604Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/56/ecb342362161b47cd8bcc604adaebc035acc87a094be30a31fb62943bf4e/pydantic_monty-0.0.16-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:483ced987c4f0082cdc9980ac7b4ea5882876aa82c548d43944f96f13da9aca6", size = 7307315, upload-time = "2026-04-19T17:45:57.526Z" },
+    { url = "https://files.pythonhosted.org/packages/71/68/2f7113aa9ec2566ee0859258a8757a7b521eda012c9629603ae65d59e7f2/pydantic_monty-0.0.16-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c4c8477264e417475bcaf3ceb4044233407272cefd58356f062a3726e0a32a90", size = 7848117, upload-time = "2026-04-19T17:46:18.129Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a8/101f38b27db1f14bbc5eb6ef8e3cbc0debd22a380f4c42fbedd08ada6c8c/pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:751ea6e8f4ae62085b43c2b891ae6e5a072e3ea26486bae2653337e8d132459e", size = 7132076, upload-time = "2026-04-19T17:46:19.733Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/72/f8555b887879e75bb1a69638fe7a0ce4444bc552520759471bbce383bc36/pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1f29f66645a690e96e9a1b892c0c0c0736341d32251ec5035612259ca03d2102", size = 7432492, upload-time = "2026-04-19T17:44:53.533Z" },
+    { url = "https://files.pythonhosted.org/packages/44/38/2af6af1f99de9db2d69da0304bb98751e643f45a0649d3fcb261e04dea03/pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ffc6730b0ed5f6f3c88f8f719df3925bfa77abb71d0259c7f175b9be79b25cfe", size = 7951882, upload-time = "2026-04-19T17:45:15.014Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/92/e51dd904ffb683557fd0f1d1527bc0dbe56d7d4bed0eacbabad51d62087d/pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d9a79337e78f3182ae029714c634c33f15dee3c75a14b0fa2c54caf041433120", size = 8177474, upload-time = "2026-04-19T17:45:34.903Z" },
+    { url = "https://files.pythonhosted.org/packages/46/22/d2f27bc1a5a057bb83c40a1b6d61950d2be63dd02aeaa2d2efc11d5422e1/pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6935b421938f31f1414a10980d27f9bd62fbd7b35228253a751ac1488abcac1d", size = 7729472, upload-time = "2026-04-19T17:44:35.557Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d3/7a604089596bdb1fcfc7fceed782cc9f0dc03486859926bf08cf10481d75/pydantic_monty-0.0.16-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:60c87b02e81f20fc621517bfc1359dd4f5f75e54e384456e583d9e7b8b728c88", size = 7305551, upload-time = "2026-04-19T17:45:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b9/cac4251a33ec43918d018b8718aa0de00a70f374583f4a63002c072a60de/pydantic_monty-0.0.16-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:dd0b67dab0fcfe1e4371b7e8e0527e4c7f1cd010d41596ba2e8a7c4aa98b476d", size = 7756871, upload-time = "2026-04-19T17:45:46.157Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b8/f5510575bbdbdd286068d6d01ed6f7fac957d42454f69f933d038ab3ff97/pydantic_monty-0.0.16-cp314-cp314-win32.whl", hash = "sha256:300bba8175bd1b92a14de19e91315e343181e3ff248990874ddb6e29a78749c5", size = 7213168, upload-time = "2026-04-19T17:45:17.07Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/63/4697d1fcbf5783c583d011d008c4e8827cc0df5a93b97e896acd688f536a/pydantic_monty-0.0.16-cp314-cp314-win_amd64.whl", hash = "sha256:adac06c7e412504fd02d16a258d39d0e8e5a82e99158caa18f0d519ba96b393d", size = 8048722, upload-time = "2026-04-19T17:44:50.118Z" },
+]
+
+[[package]]
 name = "pydantic-settings"
 version = "2.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3818,6 +4442,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
 name = "python-magic"
 version = "0.4.27"
 source = { registry = "https://pypi.org/simple" }
@@ -3873,6 +4506,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
+name = "pywinpty"
+version = "3.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/ef/2d27f30c59a67be7025b2d7858c8c2d282b74d66544b2384730b82de74fd/pywinpty-3.0.5.tar.gz", hash = "sha256:61db0db063de9865adbea66db294628f8577f608d9764a4c7d3384eeacc4e81b", size = 16223484, upload-time = "2026-06-11T00:11:58.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/ff/8bd91d4502b48bee0459bc912806fa512111905ab97d317e7cb1201b3542/pywinpty-3.0.5-cp310-cp310-win_amd64.whl", hash = "sha256:b467dcad72365bc2205ed8b6e694e817d71de269d46e56cfe267dfa9d3d30e1b", size = 2092426, upload-time = "2026-06-10T23:40:23.292Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d2/dee13e67af2300a080dea30d4da8fdb05133a7eebb39171111f0530f7e88/pywinpty-3.0.5-cp310-cp310-win_arm64.whl", hash = "sha256:7dc4046ea8e4d7f0a16dae8dfcaeeda6df7ca3a9330444d2ba5bb96138fe0a91", size = 818083, upload-time = "2026-06-10T23:42:04.203Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/5c/31feb3dd82d1b33ae0bd09ca601edb993d9da1b7f0226b3336d4b4c39e1e/pywinpty-3.0.5-cp311-cp311-win_amd64.whl", hash = "sha256:af7a8720c78776ddd6259b71dd567944f766a6cd67f8d2887fbc4973967bacda", size = 2092466, upload-time = "2026-06-10T23:44:24.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/fe/fe23e2229ffec0c10190cef5964f5c9b2dba179d23b69ae537b7ea90bcab/pywinpty-3.0.5-cp311-cp311-win_arm64.whl", hash = "sha256:c2406f54f699eab75953fb75ce805f2ae55a33a957cd070890abd454fb4b7680", size = 818395, upload-time = "2026-06-10T23:41:56.93Z" },
+    { url = "https://files.pythonhosted.org/packages/45/34/942cc95ca4e26489875aa8a95192766247a687379ec29543eebe73ec945f/pywinpty-3.0.5-cp312-cp312-win_amd64.whl", hash = "sha256:d62946adf14b15b54c0b8d785f93fe18b04da23f4ad59e2e8c4612646e9abd23", size = 2090915, upload-time = "2026-06-10T23:43:14.98Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/5b9053004844139ea8bd86209c57ade12b134b2782f383a095784c8531ec/pywinpty-3.0.5-cp312-cp312-win_arm64.whl", hash = "sha256:e9391c05fbfa7a992a97e831fc6849887b4014a614192e3d984a7ca59592b376", size = 815934, upload-time = "2026-06-10T23:41:42.384Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f4/2a464b9893cceb3b3f416356e94fdc3e1bca9476993927e4e6d99fe95382/pywinpty-3.0.5-cp313-cp313-win_amd64.whl", hash = "sha256:48db1b0ad9d0a1b81dcaaa7163a99a7808deaceb0c1b2344716dc1fc090c3c4c", size = 2090471, upload-time = "2026-06-10T23:42:11.071Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2c/a138491a0afbdb50eb79395577bd326d4b0fbde7209417d1a8087ff2493a/pywinpty-3.0.5-cp313-cp313-win_arm64.whl", hash = "sha256:2c6008fb2d3774b48693b2fcb7f2cc317ade9dc581289a964ffeeaf81307c9b5", size = 815518, upload-time = "2026-06-10T23:42:02.363Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/15/54400049a380582acd1282665c70fcf11e0bd3713679aca78e24c3aae738/pywinpty-3.0.5-cp313-cp313t-win_amd64.whl", hash = "sha256:22ce1b780d89821cc52daf6eac0708af22d93d000ce9c7c07e37489db8594598", size = 2089920, upload-time = "2026-06-10T23:44:13.395Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0c/6f24f3c0799f502259b24bdf841a99ad2b0d59df5c2525b4e2a286d14be2/pywinpty-3.0.5-cp313-cp313t-win_arm64.whl", hash = "sha256:9c2919a81bc5cfb09b86fc5a002112b2de95ca4304a07413cbeeb746a1307a5c", size = 814520, upload-time = "2026-06-10T23:43:28.588Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/23/f3cd1b1e5fc56517f54452c49f92049e7dd9ffc8a63de22a495581f50d04/pywinpty-3.0.5-cp314-cp314-win_amd64.whl", hash = "sha256:03bb3c16d691d9242267201830bcd0e64a9b663170e9042bc84b210da9de15ac", size = 2090663, upload-time = "2026-06-10T23:43:59.845Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/dd/96d6cbfc6d9ddab5c1c2f92c26545ae8997446a2ba7ee2024cd43c81f49b/pywinpty-3.0.5-cp314-cp314-win_arm64.whl", hash = "sha256:89c5c6ef08997a3b4b277b214a35fe15cab4dd6d119f0140aa71df5b1168fdbc", size = 815700, upload-time = "2026-06-10T23:40:50.001Z" },
+    { url = "https://files.pythonhosted.org/packages/30/36/d98087bce0acaa4cce7f196103cfa7be3f63ce65f52473bb3e38784ae5d9/pywinpty-3.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7b566165e0c5fdd6abe167a5ac8b954be6a843eb55a85946576d6bc1dea03d6d", size = 2090093, upload-time = "2026-06-10T23:40:58.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fd/fe2b0db922ba052ce3976a08f3fc05d0c05047c8b4ebb6102e832b8ef563/pywinpty-3.0.5-cp314-cp314t-win_arm64.whl", hash = "sha256:24366280a8aa677323da87bec729cb3ea3b35367386cece0978bdc6e4695c690", size = 814517, upload-time = "2026-06-10T23:42:34.946Z" },
 ]
 
 [[package]]
@@ -3940,6 +4595,79 @@ wheels = [
 ]
 
 [[package]]
+name = "pyzmq"
+version = "27.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/b9/52aa9ec2867528b54f1e60846728d8b4d84726630874fee3a91e66c7df81/pyzmq-27.1.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:508e23ec9bc44c0005c4946ea013d9317ae00ac67778bd47519fdf5a0e930ff4", size = 1329850, upload-time = "2025-09-08T23:07:26.274Z" },
+    { url = "https://files.pythonhosted.org/packages/99/64/5653e7b7425b169f994835a2b2abf9486264401fdef18df91ddae47ce2cc/pyzmq-27.1.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:507b6f430bdcf0ee48c0d30e734ea89ce5567fd7b8a0f0044a369c176aa44556", size = 906380, upload-time = "2025-09-08T23:07:29.78Z" },
+    { url = "https://files.pythonhosted.org/packages/73/78/7d713284dbe022f6440e391bd1f3c48d9185673878034cfb3939cdf333b2/pyzmq-27.1.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf7b38f9fd7b81cb6d9391b2946382c8237fd814075c6aa9c3b746d53076023b", size = 666421, upload-time = "2025-09-08T23:07:31.263Z" },
+    { url = "https://files.pythonhosted.org/packages/30/76/8f099f9d6482450428b17c4d6b241281af7ce6a9de8149ca8c1c649f6792/pyzmq-27.1.0-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03ff0b279b40d687691a6217c12242ee71f0fba28bf8626ff50e3ef0f4410e1e", size = 854149, upload-time = "2025-09-08T23:07:33.17Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f0/37fbfff06c68016019043897e4c969ceab18bde46cd2aca89821fcf4fb2e/pyzmq-27.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:677e744fee605753eac48198b15a2124016c009a11056f93807000ab11ce6526", size = 1655070, upload-time = "2025-09-08T23:07:35.205Z" },
+    { url = "https://files.pythonhosted.org/packages/47/14/7254be73f7a8edc3587609554fcaa7bfd30649bf89cd260e4487ca70fdaa/pyzmq-27.1.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:dd2fec2b13137416a1c5648b7009499bcc8fea78154cd888855fa32514f3dad1", size = 2033441, upload-time = "2025-09-08T23:07:37.432Z" },
+    { url = "https://files.pythonhosted.org/packages/22/dc/49f2be26c6f86f347e796a4d99b19167fc94503f0af3fd010ad262158822/pyzmq-27.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:08e90bb4b57603b84eab1d0ca05b3bbb10f60c1839dc471fc1c9e1507bef3386", size = 1891529, upload-time = "2025-09-08T23:07:39.047Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/3e/154fb963ae25be70c0064ce97776c937ecc7d8b0259f22858154a9999769/pyzmq-27.1.0-cp310-cp310-win32.whl", hash = "sha256:a5b42d7a0658b515319148875fcb782bbf118dd41c671b62dae33666c2213bda", size = 567276, upload-time = "2025-09-08T23:07:40.695Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b2/f4ab56c8c595abcb26b2be5fd9fa9e6899c1e5ad54964e93ae8bb35482be/pyzmq-27.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:c0bb87227430ee3aefcc0ade2088100e528d5d3298a0a715a64f3d04c60ba02f", size = 632208, upload-time = "2025-09-08T23:07:42.298Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e3/be2cc7ab8332bdac0522fdb64c17b1b6241a795bee02e0196636ec5beb79/pyzmq-27.1.0-cp310-cp310-win_arm64.whl", hash = "sha256:9a916f76c2ab8d045b19f2286851a38e9ac94ea91faf65bd64735924522a8b32", size = 559766, upload-time = "2025-09-08T23:07:43.869Z" },
+    { url = "https://files.pythonhosted.org/packages/06/5d/305323ba86b284e6fcb0d842d6adaa2999035f70f8c38a9b6d21ad28c3d4/pyzmq-27.1.0-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:226b091818d461a3bef763805e75685e478ac17e9008f49fce2d3e52b3d58b86", size = 1333328, upload-time = "2025-09-08T23:07:45.946Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a0/fc7e78a23748ad5443ac3275943457e8452da67fda347e05260261108cbc/pyzmq-27.1.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0790a0161c281ca9723f804871b4027f2e8b5a528d357c8952d08cd1a9c15581", size = 908803, upload-time = "2025-09-08T23:07:47.551Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/37d15eb05f3bdfa4abea6f6d96eb3bb58585fbd3e4e0ded4e743bc650c97/pyzmq-27.1.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c895a6f35476b0c3a54e3eb6ccf41bf3018de937016e6e18748317f25d4e925f", size = 668836, upload-time = "2025-09-08T23:07:49.436Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c4/2a6fe5111a01005fc7af3878259ce17684fabb8852815eda6225620f3c59/pyzmq-27.1.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bbf8d3630bf96550b3be8e1fc0fea5cbdc8d5466c1192887bd94869da17a63e", size = 857038, upload-time = "2025-09-08T23:07:51.234Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/eb/bfdcb41d0db9cd233d6fb22dc131583774135505ada800ebf14dfb0a7c40/pyzmq-27.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:15c8bd0fe0dabf808e2d7a681398c4e5ded70a551ab47482067a572c054c8e2e", size = 1657531, upload-time = "2025-09-08T23:07:52.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/21/e3180ca269ed4a0de5c34417dfe71a8ae80421198be83ee619a8a485b0c7/pyzmq-27.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:bafcb3dd171b4ae9f19ee6380dfc71ce0390fefaf26b504c0e5f628d7c8c54f2", size = 2034786, upload-time = "2025-09-08T23:07:55.047Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b1/5e21d0b517434b7f33588ff76c177c5a167858cc38ef740608898cd329f2/pyzmq-27.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e829529fcaa09937189178115c49c504e69289abd39967cd8a4c215761373394", size = 1894220, upload-time = "2025-09-08T23:07:57.172Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f2/44913a6ff6941905efc24a1acf3d3cb6146b636c546c7406c38c49c403d4/pyzmq-27.1.0-cp311-cp311-win32.whl", hash = "sha256:6df079c47d5902af6db298ec92151db82ecb557af663098b92f2508c398bb54f", size = 567155, upload-time = "2025-09-08T23:07:59.05Z" },
+    { url = "https://files.pythonhosted.org/packages/23/6d/d8d92a0eb270a925c9b4dd039c0b4dc10abc2fcbc48331788824ef113935/pyzmq-27.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:190cbf120fbc0fc4957b56866830def56628934a9d112aec0e2507aa6a032b97", size = 633428, upload-time = "2025-09-08T23:08:00.663Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/14/01afebc96c5abbbd713ecfc7469cfb1bc801c819a74ed5c9fad9a48801cb/pyzmq-27.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:eca6b47df11a132d1745eb3b5b5e557a7dae2c303277aa0e69c6ba91b8736e07", size = 559497, upload-time = "2025-09-08T23:08:02.15Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl", hash = "sha256:452631b640340c928fa343801b0d07eb0c3789a5ffa843f6e1a9cee0ba4eb4fc", size = 1306279, upload-time = "2025-09-08T23:08:03.807Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5e/c3c49fdd0f535ef45eefcc16934648e9e59dace4a37ee88fc53f6cd8e641/pyzmq-27.1.0-cp312-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1c179799b118e554b66da67d88ed66cd37a169f1f23b5d9f0a231b4e8d44a113", size = 895645, upload-time = "2025-09-08T23:08:05.301Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/b0b2504cb4e903a74dcf1ebae157f9e20ebb6ea76095f6cfffea28c42ecd/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3837439b7f99e60312f0c926a6ad437b067356dc2bc2ec96eb395fd0fe804233", size = 652574, upload-time = "2025-09-08T23:08:06.828Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43ad9a73e3da1fab5b0e7e13402f0b2fb934ae1c876c51d0afff0e7c052eca31", size = 840995, upload-time = "2025-09-08T23:08:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/bb/b79798ca177b9eb0825b4c9998c6af8cd2a7f15a6a1a4272c1d1a21d382f/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0de3028d69d4cdc475bfe47a6128eb38d8bc0e8f4d69646adfbcd840facbac28", size = 1642070, upload-time = "2025-09-08T23:08:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/80/2df2e7977c4ede24c79ae39dcef3899bfc5f34d1ca7a5b24f182c9b7a9ca/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:cf44a7763aea9298c0aa7dbf859f87ed7012de8bda0f3977b6fb1d96745df856", size = 2021121, upload-time = "2025-09-08T23:08:11.907Z" },
+    { url = "https://files.pythonhosted.org/packages/46/bd/2d45ad24f5f5ae7e8d01525eb76786fa7557136555cac7d929880519e33a/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f30f395a9e6fbca195400ce833c731e7b64c3919aa481af4d88c3759e0cb7496", size = 1878550, upload-time = "2025-09-08T23:08:13.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/2f/104c0a3c778d7c2ab8190e9db4f62f0b6957b53c9d87db77c284b69f33ea/pyzmq-27.1.0-cp312-abi3-win32.whl", hash = "sha256:250e5436a4ba13885494412b3da5d518cd0d3a278a1ae640e113c073a5f88edd", size = 559184, upload-time = "2025-09-08T23:08:15.163Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7f/a21b20d577e4100c6a41795842028235998a643b1ad406a6d4163ea8f53e/pyzmq-27.1.0-cp312-abi3-win_amd64.whl", hash = "sha256:9ce490cf1d2ca2ad84733aa1d69ce6855372cb5ce9223802450c9b2a7cba0ccf", size = 619480, upload-time = "2025-09-08T23:08:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/c012beae5f76b72f007a9e91ee9401cb88c51d0f83c6257a03e785c81cc2/pyzmq-27.1.0-cp312-abi3-win_arm64.whl", hash = "sha256:75a2f36223f0d535a0c919e23615fc85a1e23b71f40c7eb43d7b1dedb4d8f15f", size = 552993, upload-time = "2025-09-08T23:08:18.926Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cb/84a13459c51da6cec1b7b1dc1a47e6db6da50b77ad7fd9c145842750a011/pyzmq-27.1.0-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:93ad4b0855a664229559e45c8d23797ceac03183c7b6f5b4428152a6b06684a5", size = 1122436, upload-time = "2025-09-08T23:08:20.801Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b6/94414759a69a26c3dd674570a81813c46a078767d931a6c70ad29fc585cb/pyzmq-27.1.0-cp313-cp313-android_24_x86_64.whl", hash = "sha256:fbb4f2400bfda24f12f009cba62ad5734148569ff4949b1b6ec3b519444342e6", size = 1156301, upload-time = "2025-09-08T23:08:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ad/15906493fd40c316377fd8a8f6b1f93104f97a752667763c9b9c1b71d42d/pyzmq-27.1.0-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:e343d067f7b151cfe4eb3bb796a7752c9d369eed007b91231e817071d2c2fec7", size = 1341197, upload-time = "2025-09-08T23:08:24.286Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d343f3ce13db53a54cb8946594e567410b2125394dafcc0268d8dda027e0/pyzmq-27.1.0-cp313-cp313t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:08363b2011dec81c354d694bdecaef4770e0ae96b9afea70b3f47b973655cc05", size = 897275, upload-time = "2025-09-08T23:08:26.063Z" },
+    { url = "https://files.pythonhosted.org/packages/69/2d/d83dd6d7ca929a2fc67d2c3005415cdf322af7751d773524809f9e585129/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d54530c8c8b5b8ddb3318f481297441af102517602b569146185fa10b63f4fa9", size = 660469, upload-time = "2025-09-08T23:08:27.623Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/cd/9822a7af117f4bc0f1952dbe9ef8358eb50a24928efd5edf54210b850259/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3afa12c392f0a44a2414056d730eebc33ec0926aae92b5ad5cf26ebb6cc128", size = 847961, upload-time = "2025-09-08T23:08:29.672Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/12/f003e824a19ed73be15542f172fd0ec4ad0b60cf37436652c93b9df7c585/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c65047adafe573ff023b3187bb93faa583151627bc9c51fc4fb2c561ed689d39", size = 1650282, upload-time = "2025-09-08T23:08:31.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4a/e82d788ed58e9a23995cee70dbc20c9aded3d13a92d30d57ec2291f1e8a3/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:90e6e9441c946a8b0a667356f7078d96411391a3b8f80980315455574177ec97", size = 2024468, upload-time = "2025-09-08T23:08:33.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/94/2da0a60841f757481e402b34bf4c8bf57fa54a5466b965de791b1e6f747d/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:add071b2d25f84e8189aaf0882d39a285b42fa3853016ebab234a5e78c7a43db", size = 1885394, upload-time = "2025-09-08T23:08:35.51Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/6f/55c10e2e49ad52d080dc24e37adb215e5b0d64990b57598abc2e3f01725b/pyzmq-27.1.0-cp313-cp313t-win32.whl", hash = "sha256:7ccc0700cfdf7bd487bea8d850ec38f204478681ea02a582a8da8171b7f90a1c", size = 574964, upload-time = "2025-09-08T23:08:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4d/2534970ba63dd7c522d8ca80fb92777f362c0f321900667c615e2067cb29/pyzmq-27.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:8085a9fba668216b9b4323be338ee5437a235fe275b9d1610e422ccc279733e2", size = 641029, upload-time = "2025-09-08T23:08:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fa/f8aea7a28b0641f31d40dea42d7ef003fded31e184ef47db696bc74cd610/pyzmq-27.1.0-cp313-cp313t-win_arm64.whl", hash = "sha256:6bb54ca21bcfe361e445256c15eedf083f153811c37be87e0514934d6913061e", size = 561541, upload-time = "2025-09-08T23:08:42.668Z" },
+    { url = "https://files.pythonhosted.org/packages/87/45/19efbb3000956e82d0331bafca5d9ac19ea2857722fa2caacefb6042f39d/pyzmq-27.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ce980af330231615756acd5154f29813d553ea555485ae712c491cd483df6b7a", size = 1341197, upload-time = "2025-09-08T23:08:44.973Z" },
+    { url = "https://files.pythonhosted.org/packages/48/43/d72ccdbf0d73d1343936296665826350cb1e825f92f2db9db3e61c2162a2/pyzmq-27.1.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1779be8c549e54a1c38f805e56d2a2e5c009d26de10921d7d51cfd1c8d4632ea", size = 897175, upload-time = "2025-09-08T23:08:46.601Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2e/a483f73a10b65a9ef0161e817321d39a770b2acf8bcf3004a28d90d14a94/pyzmq-27.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7200bb0f03345515df50d99d3db206a0a6bee1955fbb8c453c76f5bf0e08fb96", size = 660427, upload-time = "2025-09-08T23:08:48.187Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d2/5f36552c2d3e5685abe60dfa56f91169f7a2d99bbaf67c5271022ab40863/pyzmq-27.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01c0e07d558b06a60773744ea6251f769cd79a41a97d11b8bf4ab8f034b0424d", size = 847929, upload-time = "2025-09-08T23:08:49.76Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2a/404b331f2b7bf3198e9945f75c4c521f0c6a3a23b51f7a4a401b94a13833/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:80d834abee71f65253c91540445d37c4c561e293ba6e741b992f20a105d69146", size = 1650193, upload-time = "2025-09-08T23:08:51.7Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0b/f4107e33f62a5acf60e3ded67ed33d79b4ce18de432625ce2fc5093d6388/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:544b4e3b7198dde4a62b8ff6685e9802a9a1ebf47e77478a5eb88eca2a82f2fd", size = 2024388, upload-time = "2025-09-08T23:08:53.393Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/01/add31fe76512642fd6e40e3a3bd21f4b47e242c8ba33efb6809e37076d9b/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cedc4c68178e59a4046f97eca31b148ddcf51e88677de1ef4e78cf06c5376c9a", size = 1885316, upload-time = "2025-09-08T23:08:55.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/a5f38970f9bf07cee96128de79590bb354917914a9be11272cfc7ff26af0/pyzmq-27.1.0-cp314-cp314t-win32.whl", hash = "sha256:1f0b2a577fd770aa6f053211a55d1c47901f4d537389a034c690291485e5fe92", size = 587472, upload-time = "2025-09-08T23:08:58.18Z" },
+    { url = "https://files.pythonhosted.org/packages/70/d8/78b1bad170f93fcf5e3536e70e8fadac55030002275c9a29e8f5719185de/pyzmq-27.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:19c9468ae0437f8074af379e986c5d3d7d7bfe033506af442e8c879732bedbe0", size = 661401, upload-time = "2025-09-08T23:08:59.802Z" },
+    { url = "https://files.pythonhosted.org/packages/81/d6/4bfbb40c9a0b42fc53c7cf442f6385db70b40f74a783130c5d0a5aa62228/pyzmq-27.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dc5dbf68a7857b59473f7df42650c621d7e8923fb03fa74a526890f4d33cc4d7", size = 575170, upload-time = "2025-09-08T23:09:01.418Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/81/a65e71c1552f74dec9dff91d95bafb6e0d33338a8dfefbc88aa562a20c92/pyzmq-27.1.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c17e03cbc9312bee223864f1a2b13a99522e0dc9f7c5df0177cd45210ac286e6", size = 836266, upload-time = "2025-09-08T23:09:40.048Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ed/0202ca350f4f2b69faa95c6d931e3c05c3a397c184cacb84cb4f8f42f287/pyzmq-27.1.0-pp310-pypy310_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f328d01128373cb6763823b2b4e7f73bdf767834268c565151eacb3b7a392f90", size = 800206, upload-time = "2025-09-08T23:09:41.902Z" },
+    { url = "https://files.pythonhosted.org/packages/47/42/1ff831fa87fe8f0a840ddb399054ca0009605d820e2b44ea43114f5459f4/pyzmq-27.1.0-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c1790386614232e1b3a40a958454bdd42c6d1811837b15ddbb052a032a43f62", size = 567747, upload-time = "2025-09-08T23:09:43.741Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/5c4d6807434751e3f21231bee98109aa57b9b9b55e058e450d0aef59b70f/pyzmq-27.1.0-pp310-pypy310_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:448f9cb54eb0cee4732b46584f2710c8bc178b0e5371d9e4fc8125201e413a74", size = 747371, upload-time = "2025-09-08T23:09:45.575Z" },
+    { url = "https://files.pythonhosted.org/packages/26/af/78ce193dbf03567eb8c0dc30e3df2b9e56f12a670bf7eb20f9fb532c7e8a/pyzmq-27.1.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:05b12f2d32112bf8c95ef2e74ec4f1d4beb01f8b5e703b38537f8849f92cb9ba", size = 544862, upload-time = "2025-09-08T23:09:47.448Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/c6/c4dcdecdbaa70969ee1fdced6d7b8f60cfabe64d25361f27ac4665a70620/pyzmq-27.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:18770c8d3563715387139060d37859c02ce40718d1faf299abddcdcc6a649066", size = 836265, upload-time = "2025-09-08T23:09:49.376Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/79/f38c92eeaeb03a2ccc2ba9866f0439593bb08c5e3b714ac1d553e5c96e25/pyzmq-27.1.0-pp311-pypy311_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:ac25465d42f92e990f8d8b0546b01c391ad431c3bf447683fdc40565941d0604", size = 800208, upload-time = "2025-09-08T23:09:51.073Z" },
+    { url = "https://files.pythonhosted.org/packages/49/0e/3f0d0d335c6b3abb9b7b723776d0b21fa7f3a6c819a0db6097059aada160/pyzmq-27.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53b40f8ae006f2734ee7608d59ed661419f087521edbfc2149c3932e9c14808c", size = 567747, upload-time = "2025-09-08T23:09:52.698Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/cf/f2b3784d536250ffd4be70e049f3b60981235d70c6e8ce7e3ef21e1adb25/pyzmq-27.1.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f605d884e7c8be8fe1aa94e0a783bf3f591b84c24e4bc4f3e7564c82ac25e271", size = 747371, upload-time = "2025-09-08T23:09:54.563Z" },
+    { url = "https://files.pythonhosted.org/packages/01/1b/5dbe84eefc86f48473947e2f41711aded97eecef1231f4558f1f02713c12/pyzmq-27.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c9f7f6e13dff2e44a6afeaf2cf54cee5929ad64afaf4d40b50f93c58fc687355", size = 544862, upload-time = "2025-09-08T23:09:56.509Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3987,12 +4715,36 @@ wheels = [
 ]
 
 [[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
+]
+
+[[package]]
 name = "rfc3986-validator"
 version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/da/88/f270de456dd7d11dcc808abfa291ecdd3f45ff44e3b549ffa01b126464d0/rfc3986_validator-0.1.1.tar.gz", hash = "sha256:3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055", size = 6760, upload-time = "2019-10-28T16:00:19.144Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/51/17023c0f8f1869d8806b979a2bffa3f861f26a3f1a66b094288323fba52f/rfc3986_validator-0.1.1-py2.py3-none-any.whl", hash = "sha256:2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9", size = 4242, upload-time = "2019-10-28T16:00:13.976Z" },
+]
+
+[[package]]
+name = "rfc3987-syntax"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lark" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", hash = "sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f", size = 8046, upload-time = "2025-07-18T01:05:03.843Z" },
 ]
 
 [[package]]
@@ -4182,6 +4934,15 @@ wheels = [
 ]
 
 [[package]]
+name = "send2trash"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", hash = "sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459", size = 17255, upload-time = "2026-01-14T06:27:36.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", hash = "sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c", size = 17610, upload-time = "2026-01-14T06:27:35.218Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4197,6 +4958,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]
@@ -4332,6 +5102,32 @@ wheels = [
 ]
 
 [[package]]
+name = "terminado"
+version = "0.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess", marker = "os_name != 'nt'" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
+]
+
+[[package]]
+name = "tinycss2"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4395,6 +5191,23 @@ wheels = [
 ]
 
 [[package]]
+name = "tornado"
+version = "6.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/24/95ec527ad67b76d59299e5465b3935d05e4294b7e0290a3924b7487df30b/tornado-6.5.7.tar.gz", hash = "sha256:66c513a76cda70d53907bc27cf1447557699c2e95aa48ba27a442ff61c3ddfc2", size = 519252, upload-time = "2026-06-08T17:34:51.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/dc/c7043cab6fed8ae159fc1923ce829ada35c4dbd797d408a43858ffaf9639/tornado-6.5.7-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:148b2eb15c2c765a50796172c1e499649b35f30d2e3c3d3e15913cfa56bfb163", size = 448543, upload-time = "2026-06-08T17:34:38.052Z" },
+    { url = "https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9da38de27f1da3b78a966f0dae12b5a1ea9afe72ca805d84ff06508272ddf100", size = 446707, upload-time = "2026-06-08T17:34:39.594Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d8/ef374952fd5da67d4463122c2b8e5a96536ec10b4b339254c6dcde81d01c/tornado-6.5.7-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8d759e71906ee783f8867b93bf26a265743da4c1e2f4a018464c1ba019862972", size = 449774, upload-time = "2026-06-08T17:34:41.204Z" },
+    { url = "https://files.pythonhosted.org/packages/35/37/d434c73f4c6e014b745b9b37085f34f40c022f007efff3d7fe65991899f3/tornado-6.5.7-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a46347a18f23fb92b396beebe0fb78f61dda0cc302445202c16203d8a18848b", size = 450745, upload-time = "2026-06-08T17:34:42.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/56b9aff361d7f1ab728a805ec7d7ea835f8807afa9f5cc690ea0e630efb9/tornado-6.5.7-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7778b30bef919231265e91c69963ce0f49a1e9c07ac900bbe75b19ce2575ba92", size = 450578, upload-time = "2026-06-08T17:34:43.787Z" },
+    { url = "https://files.pythonhosted.org/packages/02/30/a7444fb23aa76860a14198fab96ac79f1866b0a6e19e26c4381b0938e50f/tornado-6.5.7-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e726f0c75da7726eec023aa62751ff8878bd2737e34fbdd33b1ae5897d2200f5", size = 449985, upload-time = "2026-06-08T17:34:45.326Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/42/5f0e56c01e8d9d36f4e23f367b85ae6cae0c1ecddd5e6977d8388ad27488/tornado-6.5.7-cp39-abi3-win32.whl", hash = "sha256:f8de3bf12d3efdd0cbe7c8887868198f8a91415e3f29fcf258d9b8eb7b1d9ae4", size = 451047, upload-time = "2026-06-08T17:34:46.784Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/b393076ffb21b469eec5b328a0534cf03a3b90bfc6b1f09507cdd075d938/tornado-6.5.7-cp39-abi3-win_amd64.whl", hash = "sha256:de942f843533a039ef9fa3d9c88c7cd8a7c94553fb5ad0154270989b3d99a2c4", size = 451485, upload-time = "2026-06-08T17:34:48.248Z" },
+    { url = "https://files.pythonhosted.org/packages/71/2e/7b1c769803121b809112cf9a00681c472eae1d80e32d7ec0e0bd61d0d0e1/tornado-6.5.7-cp39-abi3-win_arm64.whl", hash = "sha256:ff934fce95643af5f11efdae618eaa73d469dc588641e5c8d19295a0c65c4796", size = 450506, upload-time = "2026-06-08T17:34:49.702Z" },
+]
+
+[[package]]
 name = "traitlets"
 version = "5.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4452,6 +5265,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+]
+
+[[package]]
+name = "uri-template"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/c7/0336f2bd0bcbada6ccef7aaa25e443c118a704f828a0620c6fa0207c1b64/uri-template-1.3.0.tar.gz", hash = "sha256:0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7", size = 21678, upload-time = "2023-06-21T01:49:05.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl", hash = "sha256:a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363", size = 11140, upload-time = "2023-06-21T01:49:03.467Z" },
 ]
 
 [[package]]
@@ -4644,6 +5466,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
+]
+
+[[package]]
+name = "webcolors"
+version = "25.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/7a/eb316761ec35664ea5174709a68bbd3389de60d4a1ebab8808bfc264ed67/webcolors-25.10.0.tar.gz", hash = "sha256:62abae86504f66d0f6364c2a8520de4a0c47b80c03fc3a5f1815fedbef7c19bf", size = 53491, upload-time = "2025-10-31T07:51:03.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl", hash = "sha256:032c727334856fc0b968f63daa252a1ac93d33db2f5267756623c210e57a4f1d", size = 14905, upload-time = "2025-10-31T07:51:01.778Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# PoC: Scalable MCP tooling — Tool Search vs. Code Mode

A runnable proof-of-concept for the [design doc](https://seequent.atlassian.net/wiki/x/_oA9kg).

It lets you **observe what the model sees** under three tool-exposure strategies, using a
self-contained demo server with mock Evo-flavored tools. **No Evo credentials or network access
required for interacting with the demo server.**

| Strategy | `list_tools()` returns | What it fixes |
|---|---|---|
| `none` | the full catalog (15 demo tools) | nothing (today's behavior) |
| `tool-search` | `search_tools`, `call_tool` | catalog bloat |
| `code-mode` | `search`, `get_schema`, `execute` | catalog bloat + round-trips + intermediate-result pollution |

## Files

- **`tool_strategy.py`** — the shared factory (`apply_strategy`, `ToolStrategy`,
  `SearchEngine`). Reads `MCP_TOOL_STRATEGY` / `MCP_SEARCH_ENGINE`. This is the *real* module wired
  into `src/mcp_tools.py` (imported from here), so the PoC exercises production wiring.
- **`demo_server.py`** — a FastMCP server with 15 mock Evo tools (tagged `read`/`write`/`admin`/
  `destructive`) that return canned data. Provides `build_demo_server(strategy, ...)` and an env-var
  `__main__` entrypoint.
- **`explore.ipynb`** — the interactive walkthrough. Run it top to bottom.

## Setup

```bash
# From the repo root
uv sync --extra poc
```

## Run the notebook

```bash
uv run --extra poc jupyter lab src/poc/explore.ipynb
```

The notebook covers:
1. What the model sees upfront (`list_tools`) in each mode, plus an approximate **context-cost**
   measurement of the upfront catalog.
2. `none` — the baseline (full catalog, one raw result per call).
3. `tool-search` — discovery on demand; BM25 vs. regex engines.
4. `code-mode` — a multi-step workflow collapsed into a single sandboxed `execute` that returns only
   the final answer.
5. **Guardrails** — hiding `destructive`-tagged tools from discovery via a `Visibility` transform.
6. **Against the live Evo MCP server (discovery only)** — the real ~46-tool catalog collapsing to
   2–3 synthetic tools, with real `search_tools` / `search` / `get_schema` calls. **No Evo
   credentials and no Evo API calls** — discovery reads the catalog only. The multi-step workflow is
   *presented* as the code the model would write, not executed.
7. A side-by-side summary table.

> Sections 1–5 use `demo_server.py` (deterministic, safe, no creds) so the executable workflow and
> destructive-guardrail cells actually run. Section 6 targets the real catalog but stays discovery-only
> so it needs no credentials and touches no live tenant.

## Run the demo server standalone

```bash
MCP_TOOL_STRATEGY=none        uv run python src/poc/demo_server.py
MCP_TOOL_STRATEGY=tool-search uv run python src/poc/demo_server.py
MCP_TOOL_STRATEGY=code-mode   uv run python src/poc/demo_server.py
```

## The same switch on the real server

The factory is wired into `src/mcp_tools.py`, applied after all tools are registered:

```bash
MCP_TOOL_STRATEGY=code-mode   uv run python src/mcp_tools.py   # 46 tools -> search/get_schema/execute
MCP_TOOL_STRATEGY=tool-search uv run python src/mcp_tools.py   # 46 tools -> search_tools/call_tool
# MCP_TOOL_STRATEGY unset / "none" -> unchanged behavior (default)
```

## Notes

- `code-mode` requires the `fastmcp[code-mode]` extra (pydantic-monty sandbox), already declared in
  the project dependencies.
- Inside the `code-mode` sandbox, `await call_tool(name, params)` returns `{"result": <value>}` — see
  the `["result"]` unwrapping in the notebook.
- These are stock FastMCP transforms (`>=3.1.0`; repo runs `3.3.1`). Code Mode is flagged
  **experimental** upstream. For production cloud use, harden the sandbox (isolated runtime, no
  network egress) as described in the design doc §7.
