### PR TITLE
Implement silent auth and allowed redirects env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,13 @@ EVO_REDIRECT_URL=http://localhost:3000/signin-callback
 #   {MCP_PUBLIC_BASE_URL}{OIDCPROXY_REDIRECT_PATH}
 # This is NOT the same as EVO_REDIRECT_URL (which is for server-managed mode only).
 # OIDCPROXY_REDIRECT_PATH=/signin-callback
-
+#
+# Optional callback allowlist for dynamically registered MCP clients.
+# Leave unset to preserve FastMCP's default behavior of accepting any callback URI.
+# Use exact URLs for hosted clients and wildcard patterns for native loopback clients.
+# This is distinct from OIDCPROXY_REDIRECT_PATH: IMS redirects to the latter, while
+# the authorization code is forwarded to one of these client callback URLs.
+# MCP_ALLOWED_CLIENT_REDIRECT_URIS=http://localhost:*,http://127.0.0.1:*
 
 MCP_TOOL_FILTER=all
 # Search path for local data files. Point this to local data you want tools to

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -249,6 +249,18 @@ If the `mcp-session-id` header is absent (fallback), the raw token is used inste
 
 When `CLIENT_DELEGATED_AUTH=true`, the OIDCProxy is configured with `require_authorization_consent="external"`. This means the built-in consent screen is skipped because Bentley IMS handles user consent/login directly as the upstream identity provider.
 
+For Bentley IMS, authorization starts with `prompt=none` to reuse an existing IMS browser session. If IMS requires interaction, the proxy retries the same transaction once without that parameter.
+
+### Optional downstream callback allowlist
+
+`MCP_ALLOWED_CLIENT_REDIRECT_URIS` optionally restricts the callback URIs that MCP clients may submit through Dynamic Client Registration. It is a comma-separated list of exact URLs or FastMCP wildcard patterns:
+
+```bash
+MCP_ALLOWED_CLIENT_REDIRECT_URIS=http://localhost:*,http://127.0.0.1:*,https://claude.ai/api/mcp/auth_callback
+```
+
+Leave it unset to preserve FastMCP's default behavior of accepting any client callback URI. This setting is distinct from `OIDCPROXY_REDIRECT_PATH`: IMS redirects to `{MCP_PUBLIC_BASE_URL}{OIDCPROXY_REDIRECT_PATH}`, then the MCP server forwards its authorization code to the registered client callback URI.
+
 | Environment | Guidance |
 |-------------|----------|
 | **Local development** | No consent warning is shown — IMS handles consent upstream. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "numpy>=1.24.0",
     "tomli; python_version < '3.11'",
     "pyjwt>=2.13.0",
+    "cachetools>=7.1.2",
 ]
 
 [project.optional-dependencies]

--- a/src/evo_mcp/client_auth.py
+++ b/src/evo_mcp/client_auth.py
@@ -5,12 +5,66 @@
 import json as _json
 import logging
 import os
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
+from cachetools import TTLCache
 from evo.oauth import EvoScopes
 from fastmcp.server.auth.oidc_proxy import OIDCProxy
+from starlette.requests import Request
+from starlette.responses import RedirectResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 logger = logging.getLogger(__name__)
+_SILENT_AUTH_ERRORS = frozenset(
+    {"account_selection_required", "consent_required", "interaction_required", "login_required"}
+)
+_AUTH_TRANSACTION_TTL_SECONDS = 15 * 60
+_ALLOWED_CLIENT_REDIRECT_URIS_ENV = "MCP_ALLOWED_CLIENT_REDIRECT_URIS"
+
+
+class SilentAuthOIDCProxy(OIDCProxy):
+    """Retry a failed silent IMS login once with normal browser interaction."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._interactive_fallback_transactions: TTLCache[str, bool] = TTLCache(
+            maxsize=10_000,
+            ttl=_AUTH_TRANSACTION_TTL_SECONDS,
+        )
+
+    async def _handle_idp_callback(self, request: Request):
+        error = request.query_params.get("error")
+        transaction_id = request.query_params.get("state")
+        if error not in _SILENT_AUTH_ERRORS or not transaction_id:
+            if transaction_id:
+                self._interactive_fallback_transactions.pop(transaction_id, None)
+            return await super()._handle_idp_callback(request)
+
+        if transaction_id in self._interactive_fallback_transactions:
+            return await super()._handle_idp_callback(request)
+
+        transaction = await self._transaction_store.get(key=transaction_id)
+        if transaction is None:
+            return await super()._handle_idp_callback(request)
+
+        self._interactive_fallback_transactions[transaction_id] = True
+        interactive_url = _without_prompt(self._build_upstream_authorize_url(transaction_id, transaction.model_dump()))
+        logger.info("Silent IMS authentication requires interaction, retrying with a normal browser login")
+        return RedirectResponse(interactive_url, status_code=302)
+
+
+def _without_prompt(url: str) -> str:
+    """Remove the silent-auth prompt parameter for the interactive fallback."""
+    parts = urlsplit(url)
+    query = urlencode([(key, value) for key, value in parse_qsl(parts.query) if key != "prompt"])
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, query, parts.fragment))
+
+
+def _allowed_client_redirect_uris() -> list[str] | None:
+    value = os.getenv(_ALLOWED_CLIENT_REDIRECT_URIS_ENV, "").strip()
+    if not value:
+        return None
+    return [uri.strip() for uri in value.split(",") if uri.strip()]
 
 
 def create_auth_provider(base_url: str):
@@ -46,7 +100,7 @@ def create_auth_provider(base_url: str):
     # The proxy authenticates upstream using PKCE only.
     evo_scopes = str(EvoScopes.all_evo)
 
-    return OIDCProxy(
+    return SilentAuthOIDCProxy(
         config_url=config_url,
         client_id=client_id,
         client_secret="unused",
@@ -54,7 +108,8 @@ def create_auth_provider(base_url: str):
         base_url=base_url,
         redirect_path=redirect_path,
         require_authorization_consent="external",
-        extra_authorize_params={"scope": evo_scopes},
+        allowed_client_redirect_uris=_allowed_client_redirect_uris(),
+        extra_authorize_params={"scope": evo_scopes, "prompt": "none"},
         # MCP clients send an RFC 8707 resource indicator (the MCP server URL).
         # Do not forward it to Bentley IMS — IMS has its own resource model and
         # rejects unknown resource URLs with invalid_target.

--- a/uv.lock
+++ b/uv.lock
@@ -815,6 +815,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "cachetools" },
     { name = "evo-compute" },
     { name = "evo-files" },
     { name = "evo-objects" },
@@ -844,6 +845,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.1" },
+    { name = "cachetools", specifier = ">=7.1.2" },
     { name = "evo-compute", specifier = ">=0.0.4" },
     { name = "evo-files", specifier = ">=0.2.4" },
     { name = "evo-objects", specifier = ">=0.4.0" },


### PR DESCRIPTION
## Description

Overwriting the _handle_idp_callback of fastmcp's OIDCProxy to handle silent auth, to sliently keep the MCP session alive with prompt=none (with delegated HTTP OAuth only).

Also implemented an "allowed client redirect URIs" environment variable, that is optional.

## Checklist

- [x] I have read the contributing guide and the code of conduct
